### PR TITLE
Fix sensitive-file protection for directory-scoped diffs

### DIFF
--- a/src/process/daemon.ts
+++ b/src/process/daemon.ts
@@ -36,7 +36,14 @@ export async function ensureBridge(workspaceRoot: string, opts: { port?: number 
 
   const logDir = ensureDir(path.join(getStateDir(), "logs"));
   const logFile = path.join(logDir, `bridge-${workspace.id}.out.log`);
-  const out = fs.openSync(logFile, "a");
+  const out = fs.openSync(logFile, "a", 0o600);
+  try {
+    // Existing files may have been created with a permissive umask. Keep the
+    // daemon's inherited stdout/stderr log owner-readable only.
+    fs.chmodSync(logFile, 0o600);
+  } catch {
+    // Windows / filesystems without chmod semantics
+  }
   const { cmd, args } = cliEntry();
   const child = spawn(
     cmd,

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -143,11 +143,10 @@ export function gitDiff(root: string, opts: GitDiffOptions = {}, relPath?: strin
   if (mode === "staged") base.push("--cached");
   if (mode === "head") base.push("HEAD");
   base.push("--");
-  if (relPath) {
-    base.push(relPath);
-  } else {
-    base.push(".", ...SENSITIVE_DIFF_EXCLUDES);
-  }
+  // Keep the sensitive-file exclusions even when the caller narrows the diff
+  // to a directory. Otherwise a request for e.g. `src` could include
+  // `src/.env` or another secret nested below that directory.
+  base.push(relPath || ".", ...SENSITIVE_DIFF_EXCLUDES);
 
   const result = runGit(root, base);
   if (!result.ok && /not a git repository/i.test(result.stderr)) {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -103,6 +103,14 @@ describe("gitDiff pagination", () => {
     git(repo, "rm", "-f", "--cached", ".env");
   });
 
+  it("excludes sensitive files from directory-scoped diffs", () => {
+    write(repo, "private/.env", "SECRET=1\n");
+    git(repo, "add", "-f", "private/.env");
+    const diff = gitDiff(repo, { mode: "staged" }, "private");
+    expect(diff.diff).not.toContain("SECRET=1");
+    git(repo, "rm", "-f", "--cached", "private/.env");
+  });
+
   it("handles non-repos gracefully", () => {
     const diff = gitDiff(plain, { mode: "unstaged" });
     expect(diff.isRepo).toBe(false);


### PR DESCRIPTION
## Summary

- Keep sensitive-file exclusions when a diff is scoped to a directory.
- Enforce owner-only permissions for the daemon output log, including existing files.
- Add a regression test for a sensitive file nested under a requested directory.

## Security impact

Previously, a directory-scoped diff could include a sensitive file nested below that directory because the sensitive-file exclusions were only applied to full-workspace diffs. This change applies the exclusions in both cases.

## Verification

- corepack pnpm test: 89 tests passed
- corepack pnpm build: passed
- corepack pnpm audit --prod: no known vulnerabilities found