### PR TITLE
fix(auth): harden OAuth authorization with fail-closed scope/resource validation and secure pairing-page rendering

### DIFF
--- a/src/auth/html.ts
+++ b/src/auth/html.ts
@@ -1,0 +1,27 @@
+import type { Response } from "express";
+
+/**
+ * Escapes special HTML characters to prevent XSS / HTML injection.
+ */
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Sets strict browser security headers for OAuth HTML pages.
+ */
+export function setAuthSecurityHeaders(res: Response): void {
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'"
+  );
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+}

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,9 +1,16 @@
 import { Router, type Request, type Response, urlencoded, json } from "express";
 import { randomBytes } from "node:crypto";
-import { AuthStore, SUPPORTED_SCOPES, base64UrlSha256, filterScopes, safeEqual } from "./store.js";
+import {
+  AuthStore,
+  SUPPORTED_SCOPES,
+  base64UrlSha256,
+  safeEqual,
+  validateAndFilterScopes,
+} from "./store.js";
 import { PairingManager } from "../pairing/manager.js";
 import type { Logger } from "../logger/index.js";
 import { PRODUCT_NAME } from "../version.js";
+import { escapeHtml, setAuthSecurityHeaders } from "./html.js";
 
 export interface OAuthDeps {
   store: AuthStore;
@@ -78,17 +85,21 @@ function pairingPage(opts: {
     offline_access: "Stay connected between sessions",
   };
   const scopeList = opts.scopes
-    .map((scope) => `<li>${scopeLabels[scope] ?? scope}</li>`)
+    .map((scope) => `<li>${escapeHtml(scopeLabels[scope] ?? scope)}</li>`)
     .join("");
   const errorHtml = opts.error
-    ? `<p class="error" role="alert">${opts.error}</p>`
+    ? `<p class="error" role="alert">${escapeHtml(opts.error)}</p>`
     : "";
+  const escapedWorkspaceName = escapeHtml(opts.workspaceName);
+  const escapedRequestId = escapeHtml(opts.requestId);
+  const escapedProductName = escapeHtml(PRODUCT_NAME);
+
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${PRODUCT_NAME}</title>
+<title>${escapedProductName}</title>
 <style>
   :root { color-scheme: light dark; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -114,11 +125,11 @@ function pairingPage(opts: {
 </head>
 <body>
 <div class="card">
-  <h1>${PRODUCT_NAME}</h1>
-  <p class="sub">ChatGPT is requesting access to workspace <strong>${opts.workspaceName}</strong> (read-only):</p>
+  <h1>${escapedProductName}</h1>
+  <p class="sub">ChatGPT is requesting access to workspace <strong>${escapedWorkspaceName}</strong> (read-only):</p>
   <ul>${scopeList}</ul>
   <form method="POST" action="authorize">
-    <input type="hidden" name="request_id" value="${opts.requestId}">
+    <input type="hidden" name="request_id" value="${escapedRequestId}">
     <input type="text" name="pairing_code" id="pairing_code" placeholder="XXXX-XXXX"
            autocomplete="one-time-code" autofocus maxlength="9" required>
     ${errorHtml}
@@ -192,11 +203,13 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     const query = req.query as Record<string, string | undefined>;
     const client = query.client_id ? deps.store.getClient(query.client_id) : undefined;
     if (!client) {
+      setAuthSecurityHeaders(res);
       res.status(400).send("Unknown client. Please reconnect from ChatGPT.");
       return;
     }
     const redirectUri = query.redirect_uri;
     if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
+      setAuthSecurityHeaders(res);
       res.status(400).send("Invalid redirect_uri.");
       return;
     }
@@ -215,7 +228,27 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       fail("invalid_request", "PKCE with S256 is required");
       return;
     }
-    const scopes = filterScopes(query.scope);
+    const scopeResult = validateAndFilterScopes(query.scope);
+    if (!scopeResult.ok) {
+      fail(scopeResult.error, scopeResult.description);
+      return;
+    }
+    const scopes = scopeResult.scopes;
+
+    if (query.resource) {
+      const base = deps.getBaseUrl(req);
+      const expectedResource = `${base}/mcp`;
+      const reqRes = query.resource.replace(/\/+$/, "");
+      const expRes = expectedResource.replace(/\/+$/, "");
+      if (reqRes !== expRes) {
+        fail(
+          "invalid_target",
+          `The requested resource '${query.resource}' does not match the protected resource '${expectedResource}'`
+        );
+        return;
+      }
+    }
+
     const request: PendingAuthRequest = {
       id: randomBytes(16).toString("hex"),
       clientId: client.clientId,
@@ -227,6 +260,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       expiresAt: Date.now() + 10 * 60_000,
     };
     pendingRequests.set(request.id, request);
+    setAuthSecurityHeaders(res);
     res
       .status(200)
       .type("html")
@@ -238,6 +272,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     const body = req.body as { request_id?: string; pairing_code?: string };
     const request = body.request_id ? pendingRequests.get(body.request_id) : undefined;
     if (!request) {
+      setAuthSecurityHeaders(res);
       res.status(400).send("This authorization request has expired. Please reconnect from ChatGPT.");
       return;
     }
@@ -251,6 +286,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
         no_active_session: "No active pairing session. Ask Codex to generate a pairing code.",
       };
       deps.logger.warn(`Pairing verification failed: ${verdict.reason}`);
+      setAuthSecurityHeaders(res);
       res
         .status(verdict.reason === "invalid" ? 401 : 410)
         .type("html")

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -270,9 +270,40 @@ export class AuthStore {
   }
 }
 
-export function filterScopes(requested: string | undefined): string[] {
-  if (!requested || requested.trim() === "") return [...SUPPORTED_SCOPES];
+export type ScopeValidationResult =
+  | { ok: true; scopes: Scope[] }
+  | { ok: false; error: "invalid_scope"; description: string };
+
+/**
+ * Validates requested scopes against SUPPORTED_SCOPES.
+ * Fail-closed: returns error if any requested scope is unknown/unsupported.
+ * If scope is omitted or empty, defaults to all supported scopes.
+ */
+export function validateAndFilterScopes(requested: string | undefined): ScopeValidationResult {
+  if (requested === undefined || requested.trim() === "") {
+    return { ok: true, scopes: [...SUPPORTED_SCOPES] };
+  }
   const asked = requested.split(/[\s+]+/).filter(Boolean);
-  const granted = asked.filter((scope) => (SUPPORTED_SCOPES as readonly string[]).includes(scope));
-  return granted.length > 0 ? granted : [...SUPPORTED_SCOPES];
+  if (asked.length === 0) {
+    return { ok: true, scopes: [...SUPPORTED_SCOPES] };
+  }
+  const invalid: string[] = [];
+  const valid: Scope[] = [];
+  for (const s of asked) {
+    if ((SUPPORTED_SCOPES as readonly string[]).includes(s)) {
+      if (!valid.includes(s as Scope)) {
+        valid.push(s as Scope);
+      }
+    } else {
+      invalid.push(s);
+    }
+  }
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      error: "invalid_scope",
+      description: `Unsupported scope(s): ${invalid.join(" ")}`,
+    };
+  }
+  return { ok: true, scopes: valid };
 }

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import path from "node:path";
 import { startBridge, type Bridge } from "../src/bridge/server.js";
+import { validateAndFilterScopes } from "../src/auth/store.js";
 import { makeTmpDir, cleanup, write, isolateStateDir, pkceVerifierAndChallenge } from "./helpers.js";
 
 let root: string;
@@ -268,5 +269,177 @@ describe("refresh token rotation", () => {
 
     const replayed = await refresh(initial.body.refresh_token);
     expect(replayed.status).toBe(400);
+  });
+});
+
+describe("OAuth fail-closed scope, resource validation, and security headers", () => {
+  it("validates scopes correctly in unit helper", () => {
+    expect(validateAndFilterScopes(undefined)).toEqual({
+      ok: true,
+      scopes: ["workspace.read", "workspace.search", "git.read", "execution.read", "offline_access"],
+    });
+    expect(validateAndFilterScopes("")).toEqual({
+      ok: true,
+      scopes: ["workspace.read", "workspace.search", "git.read", "execution.read", "offline_access"],
+    });
+    expect(validateAndFilterScopes("workspace.read git.read")).toEqual({
+      ok: true,
+      scopes: ["workspace.read", "git.read"],
+    });
+    const invalid = validateAndFilterScopes("totally.invalid");
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.error).toBe("invalid_scope");
+    }
+    const mixed = validateAndFilterScopes("workspace.read totally.invalid");
+    expect(mixed.ok).toBe(false);
+    if (!mixed.ok) {
+      expect(mixed.error).toBe("invalid_scope");
+    }
+  });
+
+  it("fails closed when requesting unknown scopes", async () => {
+    const clientId = await registerClient();
+    const { challenge } = pkceVerifierAndChallenge();
+
+    const authorizeUrl = new URL(`${base}/oauth/authorize`);
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("state", "scope-fail-test");
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    authorizeUrl.searchParams.set("scope", "totally.invalid");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const parsed = new URL(location!);
+    expect(parsed.searchParams.get("error")).toBe("invalid_scope");
+    expect(parsed.searchParams.get("state")).toBe("scope-fail-test");
+  });
+
+  it("fails closed when requesting mixed valid and invalid scopes", async () => {
+    const clientId = await registerClient();
+    const { challenge } = pkceVerifierAndChallenge();
+
+    const authorizeUrl = new URL(`${base}/oauth/authorize`);
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    authorizeUrl.searchParams.set("scope", "workspace.read invalid_scope_name");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+    expect(response.status).toBe(302);
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const parsed = new URL(location!);
+    expect(parsed.searchParams.get("error")).toBe("invalid_scope");
+  });
+
+  it("accepts valid /mcp resource target parameter and rejects base-only or foreign resource", async () => {
+    const clientId = await registerClient();
+    const { challenge } = pkceVerifierAndChallenge();
+
+    // 1. Valid matching resource: ${base}/mcp -> 200
+    const validUrl = new URL(`${base}/oauth/authorize`);
+    validUrl.searchParams.set("client_id", clientId);
+    validUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    validUrl.searchParams.set("response_type", "code");
+    validUrl.searchParams.set("code_challenge", challenge);
+    validUrl.searchParams.set("code_challenge_method", "S256");
+    validUrl.searchParams.set("resource", `${base}/mcp`);
+
+    const validRes = await fetch(validUrl, { redirect: "manual" });
+    expect(validRes.status).toBe(200);
+
+    // 2. Valid matching resource with trailing slash: ${base}/mcp/ -> 200
+    const validTrailingUrl = new URL(`${base}/oauth/authorize`);
+    validTrailingUrl.searchParams.set("client_id", clientId);
+    validTrailingUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    validTrailingUrl.searchParams.set("response_type", "code");
+    validTrailingUrl.searchParams.set("code_challenge", challenge);
+    validTrailingUrl.searchParams.set("code_challenge_method", "S256");
+    validTrailingUrl.searchParams.set("resource", `${base}/mcp/`);
+
+    const validTrailingRes = await fetch(validTrailingUrl, { redirect: "manual" });
+    expect(validTrailingRes.status).toBe(200);
+
+    // 3. Base-only without /mcp: ${base} -> 302 invalid_target
+    const baseOnlyUrl = new URL(`${base}/oauth/authorize`);
+    baseOnlyUrl.searchParams.set("client_id", clientId);
+    baseOnlyUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    baseOnlyUrl.searchParams.set("response_type", "code");
+    baseOnlyUrl.searchParams.set("code_challenge", challenge);
+    baseOnlyUrl.searchParams.set("code_challenge_method", "S256");
+    baseOnlyUrl.searchParams.set("resource", base);
+
+    const baseOnlyRes = await fetch(baseOnlyUrl, { redirect: "manual" });
+    expect(baseOnlyRes.status).toBe(302);
+    const baseOnlyLoc = new URL(baseOnlyRes.headers.get("location")!);
+    expect(baseOnlyLoc.searchParams.get("error")).toBe("invalid_target");
+
+    // 4. Foreign attacker resource -> 302 invalid_target
+    const foreignUrl = new URL(`${base}/oauth/authorize`);
+    foreignUrl.searchParams.set("client_id", clientId);
+    foreignUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    foreignUrl.searchParams.set("response_type", "code");
+    foreignUrl.searchParams.set("code_challenge", challenge);
+    foreignUrl.searchParams.set("code_challenge_method", "S256");
+    foreignUrl.searchParams.set("resource", "https://attacker.example.com/mcp");
+
+    const foreignRes = await fetch(foreignUrl, { redirect: "manual" });
+    expect(foreignRes.status).toBe(302);
+    const foreignLoc = new URL(foreignRes.headers.get("location")!);
+    expect(foreignLoc.searchParams.get("error")).toBe("invalid_target");
+  });
+
+  it("serves security headers and escapes dynamic content on pairing page", async () => {
+    const xssWorkspaceRoot = makeTmpDir("xss-ws");
+    write(xssWorkspaceRoot, ".c2c.json", JSON.stringify({ name: "<script>alert('xss')</script>" }));
+    const xssBridge = await startBridge({
+      workspaceRoot: xssWorkspaceRoot,
+      port: 0,
+      persistRuntime: false,
+      authStoreFile: path.join(makeTmpDir("auth-xss"), "store.json"),
+    });
+
+    try {
+      const xssBase = xssBridge.localBaseUrl();
+      const regRes = await fetch(`${xssBase}/oauth/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ client_name: "XSS-Test", redirect_uris: [REDIRECT_URI] }),
+      });
+      const client = (await regRes.json()) as { client_id: string };
+
+      const { challenge } = pkceVerifierAndChallenge();
+      const authorizeUrl = new URL(`${xssBase}/oauth/authorize`);
+      authorizeUrl.searchParams.set("client_id", client.client_id);
+      authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+      authorizeUrl.searchParams.set("response_type", "code");
+      authorizeUrl.searchParams.set("code_challenge", challenge);
+      authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+      const response = await fetch(authorizeUrl, { redirect: "manual" });
+      expect(response.status).toBe(200);
+
+      // Security headers
+      expect(response.headers.get("content-security-policy")).toContain("default-src 'none'");
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(response.headers.get("x-frame-options")).toBe("DENY");
+      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+
+      // HTML escaping
+      const html = await response.text();
+      expect(html).not.toContain("<script>alert('xss')</script>");
+      expect(html).toContain("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    } finally {
+      await xssBridge.close();
+      cleanup(xssWorkspaceRoot);
+    }
   });
 });


### PR DESCRIPTION
### Summary

This PR addresses several security and authorization correctness issues in the OAuth 2.1 authorization server and pairing flow:

1. **Fail-closed Scope Validation**:
   - Fixed a privilege escalation issue where requesting unknown or unsupported scopes would previously fall back to granting all supported scopes.
   - Requesting any unknown scope or mixed valid/invalid scopes now immediately fails closed and returns `error=invalid_scope` per RFC 6749.
   - Cleaned up the unused/deprecated `filterScopes` function and standardized on `validateAndFilterScopes`.

2. **Strict RFC 8707 Resource Audience Validation**:
   - Enforced that explicit `resource` query parameters must match the server's canonical protected resource URI (`${base}/mcp`, supporting trailing-slash normalization).
   - Base-only or foreign resource targets are rejected with `error=invalid_target`.

3. **HTML Injection & XSS Defense on Pairing Page**:
   - Extracted helper `escapeHtml` in `src/auth/html.ts`.
   - Properly escaped dynamic parameters (`workspaceName`, `requestId`, `error`, `scopes`, and `PRODUCT_NAME`) rendered into the pairing authorization HTML template.

4. **Browser Security Headers**:
   - Added strict security headers on OAuth HTML responses:
     - `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'`
     - `X-Content-Type-Options: nosniff`
     - `X-Frame-Options: DENY`
     - `Referrer-Policy: no-referrer`
     - `Cache-Control: no-store, max-age=0`

5. **Automated Regression Tests**:
   - Added comprehensive test coverage in `tests/oauth.test.ts` covering fail-closed unknown scopes, mixed scopes, valid/invalid resource targets, HTML escaping, and security response headers.

### Verification

- `pnpm test` (all 97 tests across 10 test suites pass)
- `pnpm typecheck` (clean)
- `pnpm build` (clean)