### PR TITLE
docs: reorganize READMEs into dedicated multilingual editions (EN, JA, zh-CN, zh-TW)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,171 @@
+# Codex with ChatGPT
+
+<p align="center">
+  <a href="README.md">English</a> | <strong>日本語</strong> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a>
+</p>
+
+> **ChatGPT thinks. Codex works.**  
+> ChatGPT を計画・レビューの頭脳として使い、実行は Codex が担当します。
+
+---
+
+## 解決する課題
+
+ChatGPT Plus/Pro などの有料サブスクリプション Web 版の枠が余っている一方で、コーディングエージェント（Codex）が高価で限られた API トークンを高レベルな計画やコードレビューで消費してしまう問題があります。
+
+本プロジェクトは、「思考」をすでに支払っている Web 版 ChatGPT に委託し、Codex はローカルでの実行（ファイル編集、テスト実行、エラー修正）に専念させます。
+
+API キーは不要で、リバースプロキシも不要です。公式の ChatGPT Web 画面と、安全な読み取り専用 MCP ブリッジを連携させます。
+
+## これは何ですか？
+
+**Codex with ChatGPT** は、ChatGPT Web 版をローカルの Codex コーディングセッションの「計画・レビューの頭脳」として接続し、実行権限は完全に Codex に保持させる仕組みです。
+
+リポジトリ全体が一括アップロードされることはありません。ChatGPT は OAuth 2.1 で保護された**読み取り専用** MCP（Model Context Protocol）ブリッジを通じて、必要なコード行だけをオンデマンドで取得します。
+
+## ワンプロンプト導入（非エンジニア向け）
+
+Git、Node.js、ターミナル操作に詳しくなくても大丈夫です。以下のプロンプトをそのままコーディングエージェント（Codex）に貼り付けて実行してください：
+
+```text
+Please install and configure "Codex with ChatGPT" for me, fully automatically.
+I am a non-technical user — do everything yourself:
+
+1. Check the environment: git and Node.js >= 20 must be available. Install
+   anything missing yourself (macOS: Homebrew, Windows: winget). Also install
+   cloudflared.
+2. Download: clone https://github.com/XiaoDuoYa/codex-with-chatgpt into
+   ~/codex-with-chatgpt (if it already exists, git pull to update).
+3. Build: inside that folder run `corepack pnpm install` then `corepack pnpm build`.
+4. Install the Skill: copy skill/SKILL.md to
+   ~/.codex/skills/codex-with-chatgpt/SKILL.md, and update the line
+   "The codex-with-chatgpt checkout lives at:" to the actual clone path.
+5. First-time setup: follow the SKILL.md "first-time setup" workflow
+   (run c2c setup, configure the ChatGPT connector in the BUILT-IN browser,
+   enter the pairing code). Never open a third-party browser.
+6. Only interrupt me for logins (ChatGPT / Cloudflare), CAPTCHAs or 2FA —
+   and give me exactly ONE action at a time.
+7. When done, show me the ✓ checklist and confirm the file-read test passed.
+   I don't know what MCP, OAuth, tunnels or ports are. Don't explain them.
+   If anything breaks, fix it yourself first.
+```
+
+**自動更新**: Skill は 1 日に 1 回 GitHub をチェックし、最新バージョンがあれば自動で更新されます。いつでも Codex に「Update Codex with ChatGPT」と指示して更新することも可能です。
+
+---
+
+## 手動セットアップと使い方
+
+1. **Skill の配置**: `skill/` ディレクトリを `~/.codex/skills/codex-with-chatgpt/` にコピーします。
+2. **初期設定**: Codex に **「Set up Codex with ChatGPT.」** と指示します。
+3. **通常使用**: Codex に **「Use Codex with ChatGPT to implement [タスク内容].」** と指示します。
+
+設定は Codex が自動で行い、以下のように表示されます：
+
+```
+Codex with ChatGPT
+
+✓ Project detected
+✓ Workspace Bridge started
+✓ Secure connection established
+✓ ChatGPT connected
+✓ File read test passed
+
+Ready.
+```
+
+手動での操作が必要になる可能性があるのは、ChatGPT へのログイン画面が表示された場合のみです。
+
+---
+
+## アーキテクチャと動作原理
+
+```
+             ┌───────────────────────────┐
+             │       ChatGPT Web         │
+             │  推論 / 計画 / レビュー   │
+             └──────────┬──────────▲─────┘
+                        │          │
+               MCP      │          │ Computer Use
+            データ面    │          │ 制御面（メッセージ < 1 KB）
+                        ▼          │
+             ┌─────────────────────┐
+             │      C2C Bridge     │   ローカルループバックのみリッスン
+             │  読み取り専用 MCP   │   OAuth 2.1 + ワンタイムペアリングコード
+             │  OAuth + ペアリング │   Cloudflare Quick Tunnel
+             │  Tunnel 管理        │
+             └──────────┬──────────┘
+                        │  読み取り専用
+                        ▼
+             ┌─────────────────────┐          ┌─────────────────────┐
+             │  ローカルワークスペース│◀─────────│    Codex Harness    │
+             └─────────────────────┘ 編集/git │  Shell / テスト / 修正│
+                                              └─────────────────────┘
+```
+
+- **制御面（状態メッセージ）**: Codex と ChatGPT 間では、極小の構造化された `[C2C]` 状態メッセージ（`INIT → PLAN → EXECUTED → REVIEW → DONE`）のみをやり取りします。チャット欄にファイル全文やログ、差分を貼り付けることはありません。
+- **データ面（MCP）**: ChatGPT は必要な情報を以下の 8 つの読み取り専用ツール経由で自律的に取得します：
+  `workspace_info`, `list_directory`, `read_file`, `search_workspace`, `git_status`, `git_diff`, `test_status`, `execution_summary`。
+- **独立レビュー**: Codex の実行完了後、ChatGPT は MCP を通じて実際の `git_diff` やテスト結果を直接検査し、「テストが通った」という主張を鵜呑みにせず検証します。
+
+---
+
+## セキュリティモデル
+
+- **構造的読み取り専用**: ファイル書き込み、削除、シェル実行、コミットなどの破壊的ツールはサーバー上に存在しません。プロンプトインジェクションによって不正操作が実行されるリスクを排除しています。
+- **ワークスペース境界**: 各 OAuth トークンは単一の `workspace_id` に紐づけられます。パス検証は正規化された `realpath` を使用し、シンボリックリンクや相対パス（`../`）、絶対パスによる脱出を遮断します。
+- **機密ファイルの保護**: `.env*`、秘密鍵、SSH 認証情報、クラウド認証情報などはデフォルトでアクセス拒否されます（`.env.example` は許可）。`.c2cignore` でカスタムルールを追加可能です。
+- **保護されたエンドポイント**: パブリック MCP エンドポイントは OAuth 2.1（PKCE S256、動的クライアント登録、リフレッシュトークンローテーション）を要求します。未認証リクエストは `401`、別ワークスペースのトークンは `403` を返します。
+- **使い捨ての資格情報**: 長期的な資格情報がブラウザに露出することはありません。接続にはワンタイムペアリングコード（有効期限 5 分、レート制限あり、使用後即座に破棄）を使用します。
+
+詳細は [docs/security.md](docs/security.md) をご覧ください。
+
+---
+
+## 開発者向け情報
+
+```bash
+pnpm install
+pnpm build          # -> dist/ をビルドし、c2c コマンドを公開
+pnpm test           # vitest: 単体テストおよび統合テスト
+
+c2c setup           # ブリッジ + トンネル + ペアリングコード発行を一括実行
+c2c sandbox-allow   # Codex サンドボックスの許可リストに設定ディレクトリを追加
+c2c status / doctor / pair / unpair / logs / stop
+```
+
+**要件**: Node.js >= 20、git、`cloudflared`（自動検出または Skill が自動インストール）。
+
+**ドキュメント**:
+- [アーキテクチャ](docs/architecture.md)
+- [プロトコル仕様](docs/protocol.md)
+- [セキュリティ](docs/security.md)
+- [トラブルシューティング](docs/troubleshooting.md)
+
+---
+
+## プロジェクト構成
+
+```
+src/
+  bridge/     ローカル HTTP サーバー、ポート自動復旧、管理 API
+  mcp/        8 つの読み取り専用ツール、ステートレス Streamable HTTP
+  auth/       OAuth 2.1（PKCE、動的登録、リフレッシュローテーション、失効）
+  pairing/    ワンタイムペアリングコード（CSPRNG、TTL、レート制限）
+  workspace/  パス境界制御、機密ファイルポリシー、検索、git
+  tunnel/     TunnelProvider 抽象化 + Cloudflare Quick Tunnel
+  execution/  レビューサイクル用の実行記録管理
+  process/    デーモンプロセスのライフサイクル
+  cli/        c2c コマンドラインツール
+skill/        Codex Skill 定義ファイル
+tests/        単体および統合テストスイート
+docs/         各種技術仕様およびドキュメント
+```
+
+---
+
+## 免責事項・ライセンス
+
+**非公式のコミュニティプロジェクトです。OpenAI との提携や承認はありません。**
+
+[MIT License](LICENSE) のもとで公開されています。

--- a/README.md
+++ b/README.md
@@ -1,62 +1,31 @@
 # Codex with ChatGPT
 
-> ChatGPT thinks. Codex works.
-> ChatGPT 负责思考，Codex 负责干活。
+<p align="center">
+  <strong>English</strong> | <a href="README.ja.md">日本語</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.zh-TW.md">繁體中文</a>
+</p>
 
-## The problem · 解决什么问题
+> **ChatGPT thinks. Codex works.**  
+> Use ChatGPT as the planning brain while keeping the Codex harness.
 
-**中文** — ChatGPT 付费订阅的网页版额度大量闲置，Codex 却在消耗紧张的
-API 额度做规划和 Review。本项目把"思考"交给你已付费的网页版 ChatGPT，
-Codex 只负责执行。不用 API Key、不搞逆向代理——官方网页 + 只读 MCP 桥接。
+---
 
-**EN** — ChatGPT Plus/Pro web quota sits idle while your coding agent burns
-scarce API/Codex tokens on planning and review. This project moves the
-thinking to the subscription you already pay for; Codex only executes.
-No API keys, no reverse proxy — official web UI plus a read-only MCP bridge.
+## The Problem
 
-## What it is · 这是什么
+ChatGPT Plus/Pro web quota often sits idle while your coding agent (Codex) burns scarce API tokens on high-level planning and code reviews. 
 
-**中文** — 把 ChatGPT 网页版变成 Codex 编码会话的"规划与审查大脑"，执行权
-完全保留在 Codex 手里。你的仓库永远不会被上传：ChatGPT 通过一条安全的、
-OAuth 保护的**只读** MCP 连接，按需读取当前工作区里它真正需要的那几行代码。
+This project offloads the "thinking" to the web ChatGPT subscription you already pay for, while Codex handles all local execution (editing files, running tests, fixing errors). 
 
-**EN** — Use the ChatGPT web app as the planning and review brain for your
-Codex coding sessions, while Codex keeps full ownership of execution. Your
-repository is never uploaded: ChatGPT reads exactly the lines it needs through
-a secure, OAuth-protected, **read-only** MCP connection to your current
-workspace.
+No API keys needed, no reverse proxies — just the official ChatGPT web interface connected to a secure, read-only MCP bridge.
 
-Detailed docs below are in English · 详细中文文档见 **[README.zh-CN.md](README.zh-CN.md)**
+## What It Is
 
-## One-paste install · 一段话安装
+**Codex with ChatGPT** connects the ChatGPT web app as the planning and review "brain" for your local coding sessions, while keeping full execution ownership in Codex.
 
-**中文** — 不懂 git、Node、终端？完全不需要懂。把下面这段话原样复制给你的
-编码 Agent（Codex），然后去倒杯咖啡：
+Your repository is never bulk-uploaded: ChatGPT reads only the specific lines or files it needs through a secure, OAuth 2.1-protected, **read-only** Model Context Protocol (MCP) bridge to your workspace.
 
-```text
-请帮我完整安装并配置 Codex with ChatGPT，全程自动，我是不懂技术的小白，
-所有事情你自己做：
+## Quick Install (One-Prompt Automation)
 
-1. 环境自检：需要 git 和 Node.js ≥ 20，缺什么就自动安装
-  （macOS 用 Homebrew，Windows 用 winget），同时安装 cloudflared。
-2. 下载：把 https://github.com/XiaoDuoYa/codex-with-chatgpt 克隆到
-   ~/codex-with-chatgpt（已存在就 git pull 更新）。
-3. 构建：在该目录里执行 corepack pnpm install 和 corepack pnpm build。
-4. 安装 Skill：把仓库里的 skill/SKILL.md 复制到
-   ~/.codex/skills/codex-with-chatgpt/SKILL.md，并把文件中
-   "The codex-with-chatgpt checkout lives at:" 那一行的路径改成实际克隆路径。
-5. 首次配置：按 SKILL.md 里的 first-time setup 流程执行
-  （运行 c2c setup，用内置浏览器打开 ChatGPT 配置连接器并输入配对码）。
-   全程只用内置浏览器，禁止打开任何第三方浏览器。
-6. 只有遇到需要我登录（ChatGPT / Cloudflare）、验证码或两步验证时才叫我，
-   而且一次只告诉我一个动作。
-7. 完成后给我看 ✓ 清单，并确认文件读取测试通过。我不懂 MCP、OAuth、
-   Tunnel、端口这些词，不要向我解释；出了问题先自己修。
-```
-
-
-**EN** — Don't know git, Node, or terminals? You don't need to. Copy the
-paragraph below, paste it to your coding agent (Codex), and go grab a coffee:
+Don't know git, Node, or terminals? You don't need to. Copy the prompt below, paste it directly to your coding agent (Codex), and grab a coffee:
 
 ```text
 Please install and configure "Codex with ChatGPT" for me, fully automatically.
@@ -81,26 +50,17 @@ I am a non-technical user — do everything yourself:
    If anything breaks, fix it yourself first.
 ```
 
-
-**Updates · 更新** — The Skill checks GitHub once a day and updates itself when a
-new version is released; no action needed. You can also say "更新 Codex with ChatGPT"
-anytime. / Skill 每天自动检查一次 GitHub，有新版本会自动更新，无需任何操作；
-也可以随时对 Codex 说"更新 Codex with ChatGPT"。
+**Automatic Updates**: The Skill checks GitHub once a day and updates itself automatically. You can also tell Codex **"Update Codex with ChatGPT"** anytime.
 
 ---
 
-*The sections below are in English. 以下详细内容为英文，中文完整版见
-[README.zh-CN.md](README.zh-CN.md)。*
+## Manual Setup & Usage
 
-## Install → Setup → Use (manual)
+1. **Install Skill**: Copy the `skill/` directory to `~/.codex/skills/codex-with-chatgpt/`.
+2. **Initial Setup**: Tell Codex: **"Set up Codex with ChatGPT."**
+3. **Use Normally**: Tell Codex: **"Use Codex with ChatGPT to implement [feature/task]."**
 
-1. Install the Codex Skill: copy `skill/` to `~/.codex/skills/codex-with-chatgpt/`.
-2. Tell Codex: **"Set up Codex with ChatGPT."** (中文: "使用 Codex with ChatGPT 完成首次配置。")
-3. Use Codex normally: **"Use Codex with ChatGPT to implement XXX."**
-
-That's the whole manual. You don't need to know what MCP, OAuth, tunnels,
-ports or localhost are — Codex configures everything automatically and you
-just see:
+Codex handles configuration automatically and displays:
 
 ```
 Codex with ChatGPT
@@ -114,9 +74,11 @@ Codex with ChatGPT
 Ready.
 ```
 
-The only step that may need you: logging into ChatGPT (and nothing else).
+The only step that may require your interaction is logging into ChatGPT if prompted.
 
-## How it works
+---
+
+## How It Works
 
 ```
              ┌───────────────────────────┐
@@ -141,77 +103,69 @@ The only step that may need you: logging into ChatGPT (and nothing else).
                                               └─────────────────────┘
 ```
 
-- **Control plane (Computer Use)**: Codex and ChatGPT exchange tiny structured
-  `[C2C]` state messages — `INIT → PLAN → EXECUTED → REVIEW → DONE`. No diffs,
-  no logs, no file bodies are ever pasted.
-- **Data plane (MCP)**: ChatGPT pulls what it needs itself through 8 read-only
-  tools: `workspace_info`, `list_directory`, `read_file`, `search_workspace`,
-  `git_status`, `git_diff`, `test_status`, `execution_summary`.
-- **Independent review**: after Codex executes, ChatGPT inspects the actual
-  git diff and test records through MCP — it never trusts "all tests passed"
-  claims blindly.
+- **Control Plane (State Messages)**: Codex and ChatGPT exchange tiny structured `[C2C]` state messages (`INIT → PLAN → EXECUTED → REVIEW → DONE`). No raw file contents, logs, or full diffs are pasted into the chat.
+- **Data Plane (MCP)**: ChatGPT pulls necessary context on demand through 8 read-only tools:
+  `workspace_info`, `list_directory`, `read_file`, `search_workspace`, `git_status`, `git_diff`, `test_status`, `execution_summary`.
+- **Independent Review**: After Codex finishes code execution, ChatGPT independently inspects the real `git_diff` and test records via MCP rather than blindly trusting execution claims.
 
-## Security model (short version)
+---
 
-- **Read-only by construction**: write/delete/shell/commit tools simply do not
-  exist on the server. No prompt injection can enable them.
-- **One workspace = one boundary**: every token is bound to a single workspace;
-  path containment uses canonical realpaths (symlink/`../`/absolute-path escapes
-  are all blocked and tested).
-- **Sensitive files never leave**: `.env*`, keys, SSH, credentials are denied by
-  default (`.env.example` allowed); `.c2cignore` adds your own rules.
-- **Knowing the URL grants nothing**: the public MCP endpoint requires OAuth 2.1
-  (PKCE S256, dynamic client registration, rotating refresh tokens). Without a
-  token: 401. Wrong workspace: 403.
-- **The model never sees long-lived credentials**: the only secret that ever
-  touches a browser is a one-time pairing code (5-minute TTL, 5 attempts,
-  rate-limited, destroyed on use).
+## Security Model
 
-Full threat model: [docs/security.md](docs/security.md)
+- **Read-Only by Construction**: Write, delete, shell execution, and commit tools do not exist on the server. Prompt injection cannot enable destructive operations.
+- **One Workspace = One Boundary**: Every OAuth token is strictly bound to a single `workspace_id`. Path containment uses canonical `realpath` checks (symlinks, `../`, and absolute-path traversal are prevented).
+- **Sensitive File Protection**: `.env*`, private keys, SSH credentials, and cloud secrets are blocked by default (`.env.example` is allowed). Custom rules can be added in `.c2cignore`.
+- **Protected Endpoints**: The public MCP endpoint requires OAuth 2.1 (PKCE S256, Dynamic Client Registration, rotating refresh tokens). Unauthorized requests return `401`; cross-workspace tokens return `403`.
+- **Ephemeral Credentials**: Long-lived credentials are never exposed to the browser. Authorization uses a one-time pairing code (5-minute TTL, rate-limited, destroyed immediately upon use).
 
-## For developers
+For details, see [docs/security.md](docs/security.md).
+
+---
+
+## For Developers
 
 ```bash
 pnpm install
-pnpm build          # -> dist/, exposes the `c2c` bin
-pnpm test           # vitest: 76 tests (path security, OAuth, pairing, MCP e2e)
+pnpm build          # -> dist/, exposes the `c2c` CLI
+pnpm test           # vitest: unit and integration tests
 
-c2c setup           # bridge + tunnel + pairing code, all in one
-c2c sandbox-allow   # whitelist the settings dir in Codex (macOS + Windows)
+c2c setup           # Bridge + tunnel + pairing code all in one
+c2c sandbox-allow   # Whitelist the settings dir in Codex (macOS / Windows)
 c2c status / doctor / pair / unpair / logs / stop
 ```
 
-Requirements: Node.js >= 20, git. `cloudflared` for the public connection
-(auto-detected; the Skill installs it for you).
+**Requirements**: Node.js >= 20, git, `cloudflared` (auto-detected or installed by the Skill).
 
-Docs: [architecture](docs/architecture.md) · [protocol](docs/protocol.md) ·
-[security](docs/security.md) · [troubleshooting](docs/troubleshooting.md)
+**Documentation**:
+- [Architecture](docs/architecture.md)
+- [Protocol](docs/protocol.md)
+- [Security](docs/security.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
-## Project layout
+---
+
+## Project Layout
 
 ```
 src/
-  bridge/     loopback HTTP server, port recovery, admin API
-  mcp/        8 read-only tools, stateless Streamable HTTP
-  auth/       OAuth 2.1 (PKCE, DCR, refresh rotation, revocation)
-  pairing/    one-time pairing codes (CSPRNG, TTL, rate limits)
-  workspace/  path containment, sensitive-file policy, search, git
+  bridge/     Loopback HTTP server, port recovery, admin API
+  mcp/        8 read-only tools, stateless Streamable HTTP transport
+  auth/       OAuth 2.1 (PKCE, DCR, refresh token rotation, revocation)
+  pairing/    One-time pairing codes (CSPRNG, TTL, rate limits)
+  workspace/  Path containment, sensitive-file policy, search, git
   tunnel/     TunnelProvider abstraction + Cloudflare Quick Tunnel
-  execution/  execution records for the review loop
-  process/    daemon lifecycle
-  cli/        the c2c CLI
-skill/        the Codex Skill (the real UX layer)
-tests/        unit + integration tests
-docs/         architecture / protocol / security / troubleshooting
+  execution/  Execution records for the review loop
+  process/    Daemon lifecycle management
+  cli/        The c2c CLI commands
+skill/        The Codex Skill definition
+tests/        Unit & integration test suites
+docs/         Architecture, protocol, security, and troubleshooting docs
 ```
 
-## Status & disclaimer
+---
 
-V1. Verified end-to-end: bridge, OAuth + pairing, public tunnel, ChatGPT
-connector setup, zero-touch first-run experience.
+## Disclaimer & License
 
 **Unofficial community project. Not affiliated with or endorsed by OpenAI.**
 
-## License
-
-[MIT](LICENSE)
+Released under the [MIT License](LICENSE).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,25 +1,31 @@
 # Codex with ChatGPT
 
-[English](README.md) | **简体中文**
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.ja.md">日本語</a> | <strong>简体中文</strong> | <a href="README.zh-TW.md">繁體中文</a>
+</p>
 
-> ChatGPT 负责思考，Codex 负责干活。
+> **ChatGPT 负责思考，Codex 负责干活。**  
+> 把 ChatGPT 作为规划大脑，同时保留 Codex 的本地执行能力。
+
+---
 
 ## 解决什么问题
 
-ChatGPT 付费订阅的网页版额度大量闲置，Codex 却在消耗紧张的 API 额度做
-规划和 Review。本项目把"思考"交给你已付费的网页版 ChatGPT，Codex 只负责
-执行。不用 API Key、不搞逆向代理——官方网页 + 只读 MCP 桥接。
+ChatGPT Plus/Pro 付费订阅的网页版额度大量闲置，Codex 却在消耗紧张的 API 额度做高层规划和代码审查。
+
+本项目把“思考”交给你已付费的网页版 ChatGPT，Codex 只负责本地执行（编辑代码、跑测试、修复错误）。
+
+无需 API Key、不搞逆向代理——官方网页界面直接连接安全、只读的 MCP 桥接服务。
 
 ## 这是什么
 
-把 ChatGPT 网页版变成 Codex 编码会话的"规划与审查大脑"，而执行权完全保留在
-Codex 手里。你的仓库永远不会被上传——ChatGPT 通过一条安全的、OAuth 保护的
-**只读** MCP 连接，按需读取当前工作区里它真正需要的那几行代码。
+**Codex with ChatGPT** 把 ChatGPT 网页版变成 Codex 编码会话的“规划与审查大脑”，而执行权完全保留在 Codex 手里。
+
+你的仓库永远不会被整包上传：ChatGPT 通过一条安全的、OAuth 2.1 保护的**只读** MCP（Model Context Protocol）连接，按需读取当前工作区里真正需要的代码片段。
 
 ## 一段话安装（纯小白专用）
 
-不懂 git、Node、终端？完全不需要懂。把下面这段话原样复制给你的编码
-Agent（Codex），然后去倒杯咖啡：
+不懂 git、Node、终端？完全不需要懂。把下面这段话原样复制给你的编码 Agent（Codex），然后去倒杯咖啡：
 
 ```text
 请帮我完整安装并配置 Codex with ChatGPT，全程自动，我是不懂技术的小白，
@@ -42,17 +48,17 @@ Agent（Codex），然后去倒杯咖啡：
    Tunnel、端口这些词，不要向我解释；出了问题先自己修。
 ```
 
-**更新**：Skill 每天自动检查一次 GitHub，有新版本会自动更新并继续任务，
-无需任何操作；也可以随时对 Codex 说"更新 Codex with ChatGPT"。
+**自动更新**：Skill 每天自动检查一次 GitHub，有新版本会自动更新并继续任务，无需任何操作；也可以随时对 Codex 说“更新 Codex with ChatGPT”。
+
+---
 
 ## 安装 → 配置 → 使用（手动版）
 
-1. 安装 Codex Skill：把 `skill/` 复制到 `~/.codex/skills/codex-with-chatgpt/`。
-2. 对 Codex 说：**"使用 Codex with ChatGPT 完成首次配置。"**
-3. 之后正常使用：**"使用 Codex with ChatGPT，帮我实现 XXX。"**
+1. **安装 Skill**：把 `skill/` 目录复制到 `~/.codex/skills/codex-with-chatgpt/`。
+2. **首次配置**：对 Codex 说：**“使用 Codex with ChatGPT 完成首次配置。”**
+3. **日常使用**：对 Codex 说：**“使用 Codex with ChatGPT，帮我实现 [某功能/任务]。”**
 
-说明书到此结束。你不需要知道 MCP、OAuth、Tunnel、端口、localhost 是什么——
-Codex 会自动完成所有配置，你只会看到：
+说明书到此结束。Codex 会自动完成所有配置，你只会看到：
 
 ```
 Codex with ChatGPT
@@ -67,6 +73,8 @@ Ready.
 ```
 
 唯一可能需要你动手的步骤：登录 ChatGPT。仅此而已。
+
+---
 
 ## 工作原理
 
@@ -93,47 +101,46 @@ Ready.
                                               └─────────────────────┘
 ```
 
-- **控制面（Computer Use）**：Codex 与 ChatGPT 之间只交换极小的结构化 `[C2C]`
-  状态消息——`INIT → PLAN → EXECUTED → REVIEW → DONE`。绝不粘贴 diff、日志
-  或文件内容。
-- **数据面（MCP）**：ChatGPT 缺什么自己拉什么，共 8 个只读工具：
-  `workspace_info`、`list_directory`、`read_file`、`search_workspace`、
-  `git_status`、`git_diff`、`test_status`、`execution_summary`。
-- **独立审查**：Codex 执行完毕后，ChatGPT 通过 MCP 亲自检查真实的 git diff
-  和测试记录——绝不因为 Codex 说"测试全过"就直接相信。
+- **控制面（状态消息）**：Codex 与 ChatGPT 之间只交换极小的结构化 `[C2C]` 状态消息（`INIT → PLAN → EXECUTED → REVIEW → DONE`）。绝不在聊天框中粘贴 diff、日志或文件内容。
+- **数据面（MCP）**：ChatGPT 缺什么自己按需拉取，共 8 个只读工具：
+  `workspace_info`、`list_directory`、`read_file`、`search_workspace`、`git_status`、`git_diff`、`test_status`、`execution_summary`。
+- **独立审查**：Codex 执行完毕后，ChatGPT 通过 MCP 亲自检查真实的 `git_diff` 和测试记录——绝不盲目相信“测试全过”的口头声明。
+
+---
 
 ## 安全模型（简版）
 
-- **从构造上只读**：服务端根本不存在写文件/删除/Shell/提交类工具，任何提示
-  注入都无法启用它们。
-- **一个工作区 = 一道边界**：每个令牌绑定单一工作区；路径校验基于规范化
-  realpath（symlink、`../`、绝对路径逃逸全部被拦截并有测试覆盖）。
-- **敏感文件永不外泄**：`.env*`、密钥、SSH、各类凭据默认拒绝
-  （`.env.example` 放行）；`.c2cignore` 可追加自定义规则。
-- **知道 URL 不等于有权限**：公网 MCP 端点强制 OAuth 2.1（PKCE S256、动态
-  客户端注册、refresh token 轮换）。无令牌：401；令牌属于别的工作区：403。
-- **模型永远接触不到长期凭据**：唯一会出现在浏览器里的秘密是一次性配对码
-  （5 分钟有效、限 5 次尝试、限速、用后即毁）。
+- **从构造上只读**：服务端根本不存在写文件、删除、Shell 执行、代码提交类工具，任何提示注入都无法启用它们。
+- **一个工作区 = 一道边界**：每个令牌绑定单一工作区；路径校验基于规范化 `realpath`（symlink、`../`、绝对路径逃逸全部被拦截并有测试覆盖）。
+- **敏感文件永不外泄**：`.env*`、密钥、SSH、各类云端凭据默认拒绝（`.env.example` 放行）；`.c2cignore` 可追加自定义规则。
+- **知道 URL 不等于有权限**：公网 MCP 端点强制 OAuth 2.1（PKCE S256、动态客户端注册、refresh token 轮换）。无令牌：401；令牌属于别的工作区：403。
+- **模型永远接触不到长期凭据**：唯一会出现在浏览器里的秘密是一次性配对码（5 分钟有效、限 5 次尝试、限速、用后即毁）。
 
-完整威胁模型：[docs/security.md](docs/security.md)
+完整威胁模型见 [docs/security.md](docs/security.md)。
+
+---
 
 ## 开发者
 
 ```bash
 pnpm install
 pnpm build          # 产出 dist/，暴露 c2c 命令
-pnpm test           # vitest：76 个测试（路径安全、OAuth、配对、MCP 端到端）
+pnpm test           # vitest：单元与集成测试
 
 c2c setup           # 一条命令：Bridge + 隧道 + 配对码
 c2c sandbox-allow   # 把本地设置目录加入 Codex 沙箱白名单（macOS / Windows）
 c2c status / doctor / pair / unpair / logs / stop
 ```
 
-环境要求：Node.js >= 20、git；公网连接需要 `cloudflared`
-（自动检测，Skill 会替你安装）。
+**环境要求**：Node.js >= 20、git；公网连接需要 `cloudflared`（自动检测，Skill 会替你安装）。
 
-文档：[架构](docs/architecture.md) · [协议](docs/protocol.md) ·
-[安全](docs/security.md) · [故障排查](docs/troubleshooting.md)
+**详细文档**：
+- [架构设计](docs/architecture.md)
+- [协议规范](docs/protocol.md)
+- [安全模型](docs/security.md)
+- [故障排查](docs/troubleshooting.md)
+
+---
 
 ## 目录结构
 
@@ -148,18 +155,15 @@ src/
   execution/  审查闭环所需的执行记录
   process/    守护进程生命周期
   cli/        c2c 命令行
-skill/        Codex Skill（真正的 UX 层）
-tests/        单元 + 集成测试
-docs/         架构 / 协议 / 安全 / 故障排查
+skill/        Codex Skill 定义
+tests/        单元与集成测试
+docs/         架构、协议、安全与故障排查文档
 ```
 
-## 状态与声明
+---
 
-V1。已端到端验证：Bridge、OAuth + 配对、公网隧道、ChatGPT 连接器配置、
-零操作首次配置体验。
+## 声明与许可证
 
-**非官方社区项目，与 OpenAI 无关联，未获其背书。**
+**非官方社区项目，与 OpenAI 无关联或背书。**
 
-## 许可证
-
-[MIT](LICENSE)
+遵循 [MIT 许可证](LICENSE)。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,169 @@
+# Codex with ChatGPT
+
+<p align="center">
+  <a href="README.md">English</a> | <a href="README.ja.md">日本語</a> | <a href="README.zh-CN.md">简体中文</a> | <strong>繁體中文</strong>
+</p>
+
+> **ChatGPT 負責思考，Codex 負責幹活。**  
+> 將 ChatGPT 作為規劃大腦，同時保留 Codex 的本地執行能力。
+
+---
+
+## 解決什麼問題
+
+ChatGPT Plus/Pro 付費訂閱的網頁版額度大量閒置，Codex 卻在消耗緊張的 API 額度做高層規劃和程式碼審查。
+
+本專案把「思考」交給你已付費的網頁版 ChatGPT，Codex 只負責本地執行（修改程式碼、跑測試、修復錯誤）。
+
+無需 API Key、不搞逆向代理——官方網頁介面直接連接安全、唯讀的 MCP 橋接服務。
+
+## 這是什麼
+
+**Codex with ChatGPT** 把 ChatGPT 網頁版變成 Codex 編程工作階段的「規劃與審查大腦」，而執行權完全保留在 Codex 手裡。
+
+你的儲存庫永遠不會被整包上傳：ChatGPT 透過一條安全的、OAuth 2.1 保護的**唯讀** MCP（Model Context Protocol）連接，按需讀取當前工作區裡真正需要的程式碼片段。
+
+## 一段話安裝（純新手專用）
+
+不懂 git、Node、終端機？完全不需要懂。把下面這段話原樣複製給你的編程 Agent（Codex），然後去倒杯咖啡：
+
+```text
+請幫我完整安裝並設定 Codex with ChatGPT，全程自動，我是不懂技術的新手，
+所有事情你自己做：
+
+1. 環境自檢：需要 git 和 Node.js ≥ 20，缺什麼就自動安裝
+  （macOS 用 Homebrew，Windows 用 winget），同時安裝 cloudflared。
+2. 下載：把 https://github.com/XiaoDuoYa/codex-with-chatgpt 複製到
+   ~/codex-with-chatgpt（已存在就 git pull 更新）。
+3. 建置：在該目錄裡執行 corepack pnpm install 和 corepack pnpm build。
+4. 安裝 Skill：把儲存庫裡的 skill/SKILL.md 複製到
+   ~/.codex/skills/codex-with-chatgpt/SKILL.md，並把檔案中
+   "The codex-with-chatgpt checkout lives at:" 那一行的路徑改成實際複製路徑。
+5. 首次設定：按 SKILL.md 裡的 first-time setup 流程執行
+  （執行 c2c setup，用內建瀏覽器打開 ChatGPT 設定連接器並輸入配對碼）。
+   全程只用內建瀏覽器，禁止打開任何第三方瀏覽器。
+6. 只有遇到需要我登入（ChatGPT / Cloudflare）、驗證碼或兩步驟驗證時才叫我，
+   而且一次只告訴我一個動作。
+7. 完成後給我看 ✓ 清單，並確認檔案讀取測試通過。我不懂 MCP、OAuth、
+   Tunnel、連接埠這些詞，不要向我解釋；出了問題先自己修。
+```
+
+**自動更新**：Skill 每天自動檢查一次 GitHub，有新版本會自動更新並繼續任務，無需任何操作；也可以隨時對 Codex 說「更新 Codex with ChatGPT」。
+
+---
+
+## 安裝 → 設定 → 使用（手動版）
+
+1. **安裝 Skill**：把 `skill/` 目錄複製到 `~/.codex/skills/codex-with-chatgpt/`。
+2. **首次設定**：對 Codex 說：**「使用 Codex with ChatGPT 完成首次設定。」**
+3. **日常使用**：對 Codex 說：**「使用 Codex with ChatGPT，幫我實現 [某功能/任務]。」**
+
+說明書到此結束。Codex 會自動完成所有設定，你只會看到：
+
+```
+Codex with ChatGPT
+
+✓ 當前專案已識別
+✓ Workspace Bridge 已啟動
+✓ 安全連接已建立
+✓ ChatGPT 已連接
+✓ 檔案讀取測試通過
+
+Ready.
+```
+
+唯一可能需要你動手的步驟：登入 ChatGPT。僅此而已。
+
+---
+
+## 工作原理
+
+```
+             ┌───────────────────────────┐
+             │      ChatGPT 網頁版       │
+             │   推理 / 規劃 / 審查      │
+             └──────────┬──────────▲─────┘
+                        │          │
+               MCP      │          │ Computer Use
+              數據面    │          │ 控制面（訊息 < 1 KB）
+                        ▼          │
+             ┌─────────────────────┐
+             │      C2C Bridge     │   僅監聽本機回環地址
+             │  唯讀 MCP           │   OAuth 2.1 + 一次性配對碼
+             │  OAuth + 配對       │   Cloudflare Quick Tunnel
+             │  Tunnel 管理        │
+             └──────────┬──────────┘
+                        │  唯讀
+                        ▼
+             ┌─────────────────────┐          ┌─────────────────────┐
+             │     本地工作區      │◀─────────│    Codex Harness    │
+             └─────────────────────┘ 編輯/git │  Shell / 測試 / 修復 │
+                                              └─────────────────────┘
+```
+
+- **控制面（狀態訊息）**：Codex 與 ChatGPT 之間只交換極小的結構化 `[C2C]` 狀態訊息（`INIT → PLAN → EXECUTED → REVIEW → DONE`）。絕不在聊天框中貼上 diff、日誌或檔案內容。
+- **數據面（MCP）**：ChatGPT 缺什麼自己按需拉取，共 8 個唯讀工具：
+  `workspace_info`、`list_directory`、`read_file`、`search_workspace`、`git_status`、`git_diff`、`test_status`、`execution_summary`。
+- **獨立審查**：Codex 執行完畢後，ChatGPT 透過 MCP 親自檢查真實的 `git_diff` 和測試記錄——絕不盲目相信「測試全過」的口頭聲明。
+
+---
+
+## 安全模型（簡版）
+
+- **從構造上唯讀**：伺服端根本不存在寫檔案、刪除、Shell 執行、程式碼提交類工具，任何提示注入都無法啟用它們。
+- **一個工作區 = 一道邊界**：每個令牌綁定單一工作區；路徑校驗基於規範化 `realpath`（symlink、`../`、絕對路徑逃逸全部被攔截並有測試覆蓋）。
+- **敏感檔案永不外洩**：`.env*`、金鑰、SSH、各類雲端憑證預設拒絕（`.env.example` 放行）；`.c2cignore` 可追加自訂規則。
+- **知道 URL 不等於有權限**：公網 MCP 端點強制 OAuth 2.1（PKCE S256、動態客戶端註冊、refresh token 輪換）。無令牌：401；令牌屬於別的工作區：403。
+- **模型永遠接觸不到長期憑證**：唯一會出現在瀏覽器裡的秘密是一次性配對碼（5 分鐘有效、限 5 次嘗試、限速、用後即毀）。
+
+完整威脅模型見 [docs/security.md](docs/security.md)。
+
+---
+
+## 開發者
+
+```bash
+pnpm install
+pnpm build          # 產出 dist/，暴露 c2c 指令
+pnpm test           # vitest：單元與整合測試
+
+c2c setup           # 一條指令：Bridge + 隧道 + 配對碼
+c2c sandbox-allow   # 把本地設定目錄加入 Codex 沙箱白名單（macOS / Windows）
+c2c status / doctor / pair / unpair / logs / stop
+```
+
+**環境要求**：Node.js >= 20、git；公網連接需要 `cloudflared`（自動檢測，Skill 會替你安裝）。
+
+**詳細文件**：
+- [架構設計](docs/architecture.md)
+- [協議規範](docs/protocol.md)
+- [安全模型](docs/security.md)
+- [疑難排解](docs/troubleshooting.md)
+
+---
+
+## 目錄結構
+
+```
+src/
+  bridge/     本機回環 HTTP 服務、連接埠自動恢復、管理 API
+  mcp/        8 個唯讀工具、無狀態 Streamable HTTP
+  auth/       OAuth 2.1（PKCE、動態註冊、refresh 輪換、撤銷）
+  pairing/    一次性配對碼（CSPRNG、TTL、限速）
+  workspace/  路徑收斂、敏感檔案策略、搜尋、git
+  tunnel/     TunnelProvider 抽象 + Cloudflare Quick Tunnel
+  execution/  審查閉環所需的執行記錄
+  process/    守護進程生命週期
+  cli/        c2c 命令列
+skill/        Codex Skill 定義
+tests/        單元與整合測試
+docs/         架構、協議、安全與疑難排解文件
+```
+
+---
+
+## 聲明與授權條款
+
+**非官方社群專案，與 OpenAI 無關聯或背書。**
+
+遵循 [MIT 授權條款](LICENSE)。


### PR DESCRIPTION
### Summary

This PR cleans up the multilingual documentation structure across the repository:

1. **Reorganized `README.md` into Pure English**:
   - Eliminated the previous mixed Chinese/English interleaved paragraphs in the intro and install sections.
   - Polished into clean, idiomatic English.

2. **Standardized `README.zh-CN.md` (简体中文)**:
   - Polished and standardized into clean Simplified Chinese.

3. **Added `README.zh-TW.md` (繁體中文)**:
   - Added native Traditional Chinese documentation tailored for Traditional Chinese readers.

4. **Added `README.ja.md` (日本語)**:
   - Added native Japanese documentation for international developers.

5. **Universal Language Navigation Bar**:
   - Added standard navigation switchers across all four documents:
     `[English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md)`