### PR TITLE
fix(security): unify sensitive-file policy across MCP reads and git diff with rename provenance protection

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -211,7 +211,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         }
         return ok(
           gitDiff(
-            workspace.root,
+            workspace,
             { mode: args.mode as DiffMode, offset: args.offset, maxBytes: args.max_bytes },
             relPath
           )

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { IgnoreRules } from "./ignore.js";
 
 export interface GitCommandResult {
   ok: boolean;
@@ -125,31 +126,76 @@ export interface GitDiffResult {
   diff: string;
 }
 
-const SENSITIVE_DIFF_EXCLUDES = [
-  ":(exclude,glob)**/.env",
-  ":(exclude,glob)**/.env.*",
-  ":(exclude,glob)**/*.pem",
-  ":(exclude,glob)**/*.key",
-  ":(exclude,glob)**/id_rsa*",
-  ":(exclude,glob)**/id_ed25519*",
-];
+export interface WorkspaceLike {
+  root: string;
+  ignoreRules?: IgnoreRules;
+}
 
-export function gitDiff(root: string, opts: GitDiffOptions = {}, relPath?: string): GitDiffResult {
+export type GitTarget = string | WorkspaceLike;
+
+function getDiffModeArgs(mode: DiffMode): string[] {
+  if (mode === "staged") return ["--cached"];
+  if (mode === "head") return ["HEAD"];
+  return [];
+}
+
+function chunkSafePaths(paths: string[], maxCount = 50, maxBytes = 32 * 1024): string[][] {
+  const batches: string[][] = [];
+  let currentBatch: string[] = [];
+  let currentBytes = 0;
+
+  for (const p of paths) {
+    const pBytes = Buffer.byteLength(p, "utf8") + 12; // overhead for ":(literal)"
+    if (
+      currentBatch.length > 0 &&
+      (currentBatch.length >= maxCount || currentBytes + pBytes > maxBytes)
+    ) {
+      batches.push(currentBatch);
+      currentBatch = [];
+      currentBytes = 0;
+    }
+    currentBatch.push(p);
+    currentBytes += pBytes;
+  }
+  if (currentBatch.length > 0) {
+    batches.push(currentBatch);
+  }
+  return batches;
+}
+
+function isPathInScope(filePath: string, scope?: string): boolean {
+  if (!scope || scope === ".") return true;
+  return filePath === scope || filePath.startsWith(scope + "/");
+}
+
+export function gitDiff(
+  target: GitTarget,
+  opts: GitDiffOptions = {},
+  relPath?: string
+): GitDiffResult {
+  const root = typeof target === "string" ? target : target.root;
+  const ignoreRules =
+    typeof target === "object" && target.ignoreRules
+      ? target.ignoreRules
+      : new IgnoreRules(root);
+
   const mode = opts.mode ?? "unstaged";
   const offset = Math.max(0, Math.floor(opts.offset ?? 0));
   const maxBytes = Math.min(256 * 1024, Math.max(1024, Math.floor(opts.maxBytes ?? 64 * 1024)));
+  const modeArgs = getDiffModeArgs(mode);
 
-  const base: string[] = ["diff", "--no-color"];
-  if (mode === "staged") base.push("--cached");
-  if (mode === "head") base.push("HEAD");
-  base.push("--");
-  // Keep the sensitive-file exclusions even when the caller narrows the diff
-  // to a directory. Otherwise a request for e.g. `src` could include
-  // `src/.env` or another secret nested below that directory.
-  base.push(relPath || ".", ...SENSITIVE_DIFF_EXCLUDES);
-
-  const result = runGit(root, base);
-  if (!result.ok && /not a git repository/i.test(result.stderr)) {
+  // 1. Full-workspace inventory using NUL separation and global rename detection
+  const listArgs = [
+    "diff",
+    "--name-status",
+    "-z",
+    "--find-renames=1%",
+    ...modeArgs,
+    "--",
+    ".",
+  ];
+  const listResult = runGit(root, listArgs);
+  if (!listResult.ok) {
     return {
       isRepo: false,
       mode,
@@ -161,7 +207,100 @@ export function gitDiff(root: string, opts: GitDiffOptions = {}, relPath?: strin
       diff: "",
     };
   }
-  const full = Buffer.from(result.stdout, "utf8");
+
+  const tokens = listResult.stdout.split("\0");
+  const safePaths: string[] = [];
+  for (let i = 0; i < tokens.length; ) {
+    const status = tokens[i++];
+    if (!status) break;
+    if (status.startsWith("R") || status.startsWith("C")) {
+      const oldPath = tokens[i++];
+      const newPath = tokens[i++];
+      if (oldPath && newPath) {
+        // Layer 1: Security - EITHER side sensitive -> completely unsafe
+        const isSafe = !ignoreRules.isSensitive(oldPath) && !ignoreRules.isSensitive(newPath);
+        // Layer 2: Scope - EITHER side in scope -> relevant
+        const isRelevant = isPathInScope(oldPath, relPath) || isPathInScope(newPath, relPath);
+        if (isSafe && isRelevant) {
+          safePaths.push(oldPath, newPath);
+        }
+      }
+    } else {
+      const filePath = tokens[i++];
+      if (filePath) {
+        const isSafe = !ignoreRules.isSensitive(filePath);
+        const isRelevant = isPathInScope(filePath, relPath);
+        if (isSafe && isRelevant) {
+          safePaths.push(filePath);
+        }
+      }
+    }
+  }
+
+  if (safePaths.length === 0) {
+    return {
+      isRepo: true,
+      mode,
+      totalBytes: 0,
+      offset: 0,
+      returnedBytes: 0,
+      hasMore: false,
+      nextOffset: null,
+      diff: "",
+    };
+  }
+
+  // 2. Fetch diffs for safe paths in bounded batches (path count + argv bytes)
+  const batches = chunkSafePaths(safePaths);
+  let combinedDiff = "";
+  let totalAggregateBytes = 0;
+  const MAX_AGGREGATE_DIFF_BYTES = 64 * 1024 * 1024;
+
+  for (const batch of batches) {
+    const pathspecs = batch.map((p) => `:(literal)${p}`);
+    const diffArgs = [
+      "diff",
+      "--no-color",
+      "--find-renames=1%",
+      ...modeArgs,
+      "--",
+      ...pathspecs,
+    ];
+    const diffResult = runGit(root, diffArgs);
+    if (!diffResult.ok) {
+      // Fail closed on any batch error: never return partial silent success
+      return {
+        isRepo: false,
+        mode,
+        totalBytes: 0,
+        offset: 0,
+        returnedBytes: 0,
+        hasMore: false,
+        nextOffset: null,
+        diff: "",
+      };
+    }
+    if (diffResult.stdout) {
+      const chunkBytes = Buffer.byteLength(diffResult.stdout, "utf8");
+      if (totalAggregateBytes + chunkBytes > MAX_AGGREGATE_DIFF_BYTES) {
+        // Fail closed on aggregate cap: do not fake a partial successful diff
+        return {
+          isRepo: false,
+          mode,
+          totalBytes: 0,
+          offset: 0,
+          returnedBytes: 0,
+          hasMore: false,
+          nextOffset: null,
+          diff: "",
+        };
+      }
+      combinedDiff += diffResult.stdout;
+      totalAggregateBytes += chunkBytes;
+    }
+  }
+
+  const full = Buffer.from(combinedDiff, "utf8");
   const slice = full.subarray(offset, offset + maxBytes);
   let text = slice.toString("utf8");
   let sliceLen = slice.length;

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -115,4 +115,163 @@ describe("gitDiff pagination", () => {
     const diff = gitDiff(plain, { mode: "unstaged" });
     expect(diff.isRepo).toBe(false);
   });
+
+  it("excludes all IgnoreRules sensitive patterns across unstaged, staged, and head modes", () => {
+    const sensitiveFiles = [
+      { path: ".env", content: "SECRET_KEY=leaked-env\n", sentinel: "leaked-env" },
+      { path: ".npmrc", content: "//registry.npmjs.org/:_authToken=leaked-npm\n", sentinel: "leaked-npm" },
+      { path: ".netrc", content: "machine github.com password leaked-netrc\n", sentinel: "leaked-netrc" },
+      { path: ".aws/credentials", content: "aws_secret_access_key=leaked-aws\n", sentinel: "leaked-aws" },
+      { path: "nested/.ssh/config", content: "IdentityFile leaked-ssh\n", sentinel: "leaked-ssh" },
+      { path: "credentials.json", content: '{"client_secret": "leaked-creds"}\n', sentinel: "leaked-creds" },
+      { path: "service-account-prod.json", content: '{"private_key": "leaked-sa"}\n', sentinel: "leaked-sa" },
+      { path: "secrets.json", content: '{"db_pass": "leaked-secrets"}\n', sentinel: "leaked-secrets" },
+      { path: "id_ed25519", content: "-----BEGIN OPENSSH PRIVATE KEY-----\nleaked-key\n", sentinel: "leaked-key" },
+    ];
+
+    // Also include a safe file to confirm normal diffs are returned alongside excluded secrets
+    write(repo, "src/safe.ts", "export const safe = 1;\n");
+    git(repo, "add", "src/safe.ts");
+    git(repo, "commit", "-m", "add safe file");
+
+    for (const item of sensitiveFiles) {
+      write(repo, item.path, item.content);
+      git(repo, "add", "-f", item.path);
+    }
+
+    // 1. Staged mode
+    const stagedDiff = gitDiff(repo, { mode: "staged" });
+    for (const item of sensitiveFiles) {
+      expect(stagedDiff.diff).not.toContain(item.sentinel);
+    }
+
+    // Commit them so we can test unstaged changes and HEAD diffs
+    git(repo, "commit", "-m", "tracked sensitive files");
+
+    // 2. Unstaged modifications to tracked sensitive files + normal file
+    for (const item of sensitiveFiles) {
+      write(repo, item.path, item.content + "# modified-unstaged\n");
+    }
+    write(repo, "src/safe.ts", "export const safe = 2; // modified-safe\n");
+
+    const unstagedDiff = gitDiff(repo, { mode: "unstaged" });
+    expect(unstagedDiff.diff).toContain("modified-safe");
+    for (const item of sensitiveFiles) {
+      expect(unstagedDiff.diff).not.toContain(item.sentinel);
+      expect(unstagedDiff.diff).not.toContain("modified-unstaged");
+    }
+
+    // 3. Head mode
+    const headDiff = gitDiff(repo, { mode: "head" });
+    expect(headDiff.diff).toContain("modified-safe");
+    for (const item of sensitiveFiles) {
+      expect(headDiff.diff).not.toContain(item.sentinel);
+    }
+
+    // Clean up
+    git(repo, "checkout", "--", "src/safe.ts", ...sensitiveFiles.map((s) => s.path));
+  });
+
+  it("allows .env.example while blocking .env", () => {
+    write(repo, ".env.example", "API_URL=https://example.com\n");
+    write(repo, ".env", "API_KEY=supersecret-123\n");
+    git(repo, "add", "-f", ".env.example", ".env");
+
+    const diff = gitDiff(repo, { mode: "staged" });
+    expect(diff.diff).toContain(".env.example");
+    expect(diff.diff).toContain("https://example.com");
+    expect(diff.diff).not.toContain("supersecret-123");
+
+    git(repo, "rm", "-f", "--cached", ".env.example", ".env");
+  });
+
+  it("respects custom rules in .c2cignore for git diff", () => {
+    write(repo, ".c2cignore", "private-notes/\ncustom-secret.txt\n");
+    write(repo, "private-notes/secret.md", "CONFIDENTIAL DATA\n");
+    write(repo, "custom-secret.txt", "TOP_SECRET_FLAG=1\n");
+    write(repo, "public.txt", "PUBLIC CONTENT\n");
+    git(repo, "add", "-f", ".c2cignore", "private-notes/secret.md", "custom-secret.txt", "public.txt");
+
+    const diff = gitDiff(repo, { mode: "staged" });
+    expect(diff.diff).toContain("public.txt");
+    expect(diff.diff).toContain("PUBLIC CONTENT");
+    expect(diff.diff).not.toContain("CONFIDENTIAL DATA");
+    expect(diff.diff).not.toContain("TOP_SECRET_FLAG");
+
+    git(repo, "rm", "-f", "--cached", ".c2cignore", "private-notes/secret.md", "custom-secret.txt", "public.txt");
+  });
+
+  it("handles rename provenance: sensitive->safe, safe->sensitive, safe->safe", () => {
+    // 1. Commit baseline files
+    write(repo, "old_safe.ts", "export const value = 'old-safe-data';\n");
+    write(repo, ".npmrc", "//registry.npmjs.org/:_authToken=npm-secret-token\n");
+    write(repo, "public_to_secret.txt", "harmless text\n");
+    git(repo, "add", "-f", "old_safe.ts", ".npmrc", "public_to_secret.txt");
+    git(repo, "commit", "-m", "init rename baseline");
+
+    // Case A: Safe -> Safe rename
+    git(repo, "mv", "old_safe.ts", "new_safe.ts");
+    // Case B: Sensitive -> Safe rename (Must be excluded!)
+    git(repo, "mv", ".npmrc", "renamed_public.txt");
+    // Case C: Safe -> Sensitive rename (Must be excluded!)
+    git(repo, "mv", "public_to_secret.txt", ".env.secret");
+
+    const stagedDiff = gitDiff(repo, { mode: "staged" });
+
+    // Safe->safe rename should appear
+    expect(stagedDiff.diff).toContain("old_safe.ts");
+    expect(stagedDiff.diff).toContain("new_safe.ts");
+
+    // Sensitive->safe must NOT leak
+    expect(stagedDiff.diff).not.toContain("npm-secret-token");
+    expect(stagedDiff.diff).not.toContain(".npmrc");
+    expect(stagedDiff.diff).not.toContain("renamed_public.txt");
+
+    // Safe->sensitive must NOT appear as sensitive patch
+    expect(stagedDiff.diff).not.toContain(".env.secret");
+
+    // Reset repo
+    git(repo, "reset", "--hard", "HEAD");
+  });
+
+  it("prevents cross-boundary scoped rename provenance leaks with path= scoping", () => {
+    // Baseline files
+    write(repo, ".npmrc", "//registry.npmjs.org/:_authToken=cross-scope-secret\n");
+    write(repo, "src/.npmrc", "//registry.npmjs.org/:_authToken=src-secret\n");
+    write(repo, "root_safe.ts", "export const rootSafe = 1;\n");
+    write(repo, "public.txt", "public content\n");
+    git(repo, "add", "-f", ".npmrc", "src/.npmrc", "root_safe.ts", "public.txt");
+    git(repo, "commit", "-m", "baseline for cross-scope rename");
+
+    // 1. Root .npmrc renamed to src/public.txt -> scoped git_diff(path="src")
+    git(repo, "mv", ".npmrc", "src/public.txt");
+
+    // 2. public.txt renamed to src/.env -> scoped git_diff(path="src")
+    git(repo, "mv", "public.txt", "src/.env");
+
+    // 3. Safe root_safe.ts renamed to src/new_safe.ts -> scoped git_diff(path="src")
+    git(repo, "mv", "root_safe.ts", "src/new_safe.ts");
+
+    // 4. src/.npmrc renamed to root_secret_leak.txt -> scoped git_diff(path="src")
+    git(repo, "mv", "src/.npmrc", "root_secret_leak.txt");
+
+    const srcDiff = gitDiff(repo, { mode: "staged" }, "src");
+
+    // Safe cross-scope rename is visible
+    expect(srcDiff.diff).toContain("root_safe.ts");
+    expect(srcDiff.diff).toContain("src/new_safe.ts");
+
+    // Sensitive->safe cross-scope rename MUST NOT leak
+    expect(srcDiff.diff).not.toContain("cross-scope-secret");
+    expect(srcDiff.diff).not.toContain("src/public.txt");
+
+    // Safe->sensitive cross-scope rename MUST NOT appear
+    expect(srcDiff.diff).not.toContain("src/.env");
+
+    // Sensitive deletion from src MUST NOT appear
+    expect(srcDiff.diff).not.toContain("src-secret");
+    expect(srcDiff.diff).not.toContain("root_secret_leak.txt");
+
+    git(repo, "reset", "--hard", "HEAD");
+  });
 });

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -187,4 +187,63 @@ describe("MCP tools over Streamable HTTP", () => {
     expect(allowed.isError ?? false).toBe(false);
     await limitedClient.close();
   });
+
+  it("git_diff over MCP excludes sensitive files like .npmrc and service-account*.json", async () => {
+    write(root, ".npmrc", "//registry.npmjs.org/:_authToken=supersecret-npm-token\n");
+    write(root, "service-account-test.json", '{"private_key": "supersecret-sa-key"}\n');
+    write(root, "src/visible.ts", "export const visible = 'safe-change';\n");
+
+    git(root, "add", "-f", ".npmrc", "service-account-test.json", "src/visible.ts");
+
+    const result = jsonOf<{ diff: string; isRepo: boolean }>(
+      await client.callTool({ name: "git_diff", arguments: { mode: "staged" } })
+    );
+
+    expect(result.isRepo).toBe(true);
+    expect(result.diff).toContain("safe-change");
+    expect(result.diff).not.toContain("supersecret-npm-token");
+    expect(result.diff).not.toContain("supersecret-sa-key");
+
+    git(root, "rm", "-f", "--cached", ".npmrc", "service-account-test.json", "src/visible.ts");
+  });
+
+  it("git_diff over MCP blocks sensitive-to-safe renames from leaking original content", async () => {
+    write(root, ".npmrc", "//registry.npmjs.org/:_authToken=mcp-secret-token-123\n");
+    git(root, "add", "-f", ".npmrc");
+    git(root, "commit", "-m", "add secret to rename");
+
+    git(root, "mv", ".npmrc", "public_harmless.txt");
+
+    const result = jsonOf<{ diff: string; isRepo: boolean }>(
+      await client.callTool({ name: "git_diff", arguments: { mode: "staged" } })
+    );
+
+    expect(result.isRepo).toBe(true);
+    expect(result.diff).not.toContain("mcp-secret-token-123");
+    expect(result.diff).not.toContain("public_harmless.txt");
+
+    git(root, "reset", "--hard", "HEAD");
+  });
+
+  it("git_diff over MCP with path='src' blocks cross-boundary rename leaks from root secrets", async () => {
+    write(root, ".npmrc", "//registry.npmjs.org/:_authToken=root-mcp-scoped-secret\n");
+    git(root, "add", "-f", ".npmrc");
+    git(root, "commit", "-m", "add root secret for scoped test");
+
+    // Rename root .npmrc to src/public.txt
+    git(root, "mv", ".npmrc", "src/public.txt");
+
+    const result = jsonOf<{ diff: string; isRepo: boolean }>(
+      await client.callTool({
+        name: "git_diff",
+        arguments: { mode: "staged", path: "src" },
+      })
+    );
+
+    expect(result.isRepo).toBe(true);
+    expect(result.diff).not.toContain("root-mcp-scoped-secret");
+    expect(result.diff).not.toContain("src/public.txt");
+
+    git(root, "reset", "--hard", "HEAD");
+  });
 });


### PR DESCRIPTION
### Summary

This PR addresses security and sensitive file exposure risks in `git_diff`, eliminating policy drift between MCP file reading and git diffing:

1. **Centralized Policy Enforcement (`IgnoreRules.isSensitive`)**:
   - Removed hardcoded, incomplete `SENSITIVE_DIFF_EXCLUDES` from `src/workspace/git.ts`.
   - `gitDiff()` now uses the central `workspace.ignoreRules.isSensitive()` as the single source of truth, ensuring `.npmrc`, `.netrc`, `.aws/credentials`, `.ssh/`, `credentials.json`, `service-account*.json`, `secrets.json`, and `.c2cignore` custom rules are consistently excluded.

2. **Global Rename Provenance Defense**:
   - The security inventory runs full-workspace (`git diff --name-status -z --find-renames=1% -- .`) rather than scoped to caller paths, preventing Git from losing rename provenance across directory boundaries.
   - Implemented two-layer filtering: checks both `oldPath` and `newPath` against `isSensitive()` before applying caller scope filters.
   - Completely closes the bypass where renaming a root secret (e.g. `.npmrc` -> `src/public.txt`) and requesting `git_diff(path="src")` would previously emit the secret contents as an added file patch.

3. **Literal Pathspecs & Dual-Budget Batching**:
   - Uses `:(literal)` pathspecs to avoid Git glob magic injection from unusual file names.
   - Batches safe path queries by both path count (max 50) and argv byte budget (32 KiB) to prevent `E2BIG` errors on systems with tight argument limits.

4. **Fail-Closed Reliability & Resource Safety**:
   - Command errors in any diff batch immediately fail closed (`isRepo: false`) instead of returning silent partial results.
   - Aggregated diff output is bounded with a 64 MiB cap, failing closed rather than returning truncated diffs masked as full successes.

5. **Comprehensive Automated Tests**:
   - Added unit tests in `tests/git.test.ts` covering table-driven sensitive patterns, unstaged/staged/head modes, directory-scoped diffs, `.env.example` allowlist behavior, `.c2cignore` rules, and cross-boundary scoped renames.
   - Added end-to-end integration tests in `tests/mcp-integration.test.ts` verifying sensitive file and scoped rename exclusion over the MCP HTTP transport.

### Verification

- `pnpm test` (all 100 tests across 10 suites pass)
- `pnpm typecheck` (clean)
- `pnpm build` (clean)