### PR TITLE
fix(search): match root files for recursive globs in Node fallback

### DIFF
--- a/src/workspace/search.ts
+++ b/src/workspace/search.ts
@@ -178,10 +178,12 @@ async function searchWithNode(
 function globToRegex(glob: string): RegExp {
   const escaped = glob
     .replace(/[.+^${}()|[\]]/g, "\\$&")
-    .replace(/\*\*/g, "\u0000")
+    .replace(/\*\*\//g, "\u0000")
+    .replace(/\*\*/g, "\u0001")
     .replace(/\*/g, "[^/]*")
-    .replace(/\u0000/g, ".*")
-    .replace(/\?/g, "[^/]");
+    .replace(/\?/g, "[^/]")
+    .replace(/\u0000/g, "(?:.*/)?")
+    .replace(/\u0001/g, ".*");
   return new RegExp(`(^|/)${escaped}$`, "i");
 }
 

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -5,11 +5,14 @@ import { makeTmpDir, cleanup, write } from "./helpers.js";
 
 let root: string;
 let ws: Workspace;
+const globMarker = "C2C_GLOB_MARKER";
 
 beforeAll(() => {
   root = makeTmpDir("search-ws");
   write(root, "src/auth.ts", "export function login() { return 'needle-alpha'; }\n");
-  write(root, "src/deep/nested.ts", "// needle-alpha appears here too\n");
+  write(root, "src/deep/nested.ts", `// needle-alpha appears here too\n${globMarker}\n`);
+  write(root, "src/root.ts", `${globMarker}\n`);
+  write(root, "root.ts", `${globMarker}\n`);
   write(root, "README.md", "This project contains needle-alpha documentation.\n");
   write(root, ".env", "NEEDLE-ALPHA=secret\n");
   write(root, "node_modules/pkg/index.js", "needle-alpha in dependencies\n");
@@ -71,6 +74,13 @@ describe.each(engines())("search engine: %s", (engine) => {
     const paths = result.matches.map((match) => match.path);
     expect(paths).toContain("README.md");
     expect(paths.some((p) => p.endsWith(".ts"))).toBe(false);
+  });
+
+  it("matches root and nested files for recursive globs", async () => {
+    configure();
+    const result = await searchWorkspace(ws, { query: globMarker, glob: "**/*.ts" });
+    const paths = result.matches.map((match) => match.path).sort();
+    expect(paths).toEqual(["root.ts", "src/deep/nested.ts", "src/root.ts"]);
   });
 
   it("restricts search to a subdirectory", async () => {


### PR DESCRIPTION
## Summary

Fix the Node search fallback so recursive globs such as `**/*.ts` also match files in the workspace root, keeping its behavior aligned with ripgrep.

Previously, `**` was translated to `.*` while the following `/` remained mandatory. As a result, `**/*.ts` required at least one directory level and skipped root-level files.

This changes only the `**/` translation so the directory prefix can be absent, while preserving the existing behavior for ordinary `*`, `?`, and escaping.

## Regression coverage

Added a test covering both root-level and nested TypeScript files for `**/*.ts`, with Node fallback and ripgrep expected to return the same matches.

Manual verification also covered nearby glob behavior including `src/**/*.ts`, `*.ts`, `src/*.ts`, `?`, and literal escaping.

## Verification

- Reproducer before the fix: Node fallback omitted `root.ts` while ripgrep returned it.
- After the fix: both engines return `root.ts`, `src/root.ts`, and `src/deep/nested.ts`.
- `git diff --check`: passed.
- Full `pnpm test`, `pnpm typecheck`, and `pnpm build` could not be run locally because the execution environment could not resolve `registry.npmjs.org` (`ENOTFOUND`) and the required dependency tarballs were not available offline.

No package or lockfile changes were made while attempting verification.