### PR TITLE
Harden local bridge security boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The only step that may need you: logging into ChatGPT (and nothing else).
   (PKCE S256, dynamic client registration, rotating refresh tokens). Without a
   token: 401. Wrong workspace: 403.
 - **The model never sees long-lived credentials**: the only secret that ever
-  touches a browser is a one-time pairing code (5-minute TTL, 5 attempts,
+  touches a browser is a one-time pairing code (5-minute TTL, 5 attempts per authorization request,
   rate-limited, destroyed on use).
 
 Full threat model: [docs/security.md](docs/security.md)
@@ -174,7 +174,7 @@ Full threat model: [docs/security.md](docs/security.md)
 ```bash
 pnpm install
 pnpm build          # -> dist/, exposes the `c2c` bin
-pnpm test           # vitest: 76 tests (path security, OAuth, pairing, MCP e2e)
+pnpm test           # path security, OAuth, pairing and MCP end-to-end tests
 
 c2c setup           # bridge + tunnel + pairing code, all in one
 c2c sandbox-allow   # whitelist the settings dir in Codex (macOS + Windows)

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,17 +17,17 @@
 | Threat | Mitigation |
 | --- | --- |
 | MCP URL leaks | URL alone is useless: every `/mcp` request requires a valid bearer token (401 without, 403 wrong workspace) |
-| Pairing code brute force | 8 chars from a 31-char CSPRNG alphabet (~40 bits), 5 attempts per session, per-IP rate limit (10/min), 5-minute TTL, one-time use, session destroyed on limit |
+| Pairing code brute force | 8 chars from a 31-char CSPRNG alphabet (~40 bits), 5 attempts per authorization request, per-IP rate limit (10/min), 5-minute TTL, one-time use; hostile requests cannot invalidate another request's code |
 | OAuth CSRF | `state` round-tripped verbatim; authorization requests are server-side records keyed by random ids |
 | Code interception | PKCE S256 mandatory (plain rejected); authorization codes are one-time, 5-minute TTL, bound to client + redirect URI |
 | Token theft | Opaque high-entropy tokens; stored only as SHA-256 hashes; access tokens live 1 h; refresh tokens rotate on every use (replay of the old one fails); revocation endpoint + `c2c unpair` |
 | Workspace traversal | `realpath` canonicalization of the deepest existing ancestor; containment check against the canonical root; case-insensitive comparison on macOS/Windows; rejects `..`, absolute escapes, backslash tricks, null bytes |
 | Symlink escape | Canonicalization resolves symlinks before the containment check (file and directory symlinks both covered by tests) |
 | Sensitive files | Deny-by-default patterns (.env*, keys, SSH, cloud creds, keychains…) enforced at resolve time — reads, listings, and search all pass through the same gate; `git diff` adds pathspec excludes; `.env.example` allowed |
-| Oversized file / diff DoS | read_file caps lines and bytes per response; git_diff paginates by byte offset with hard caps; search caps matches and file sizes |
-| Tunnel exposure | Bridge binds 127.0.0.1 only (refuses 0.0.0.0); the only public surface is HTTPS via the tunnel, protected by OAuth; `/health` reveals only a salted workspace hash |
-| Admin API abuse | Loopback-only + random admin token (0600 runtime file) + requests with proxy headers (`cf-connecting-ip`, `x-forwarded-for`) rejected; unauthenticated probes get 404 |
-| Log credential leakage | Logger redacts token prefixes, bearer headers, token-like parameters, and pairing-code-shaped strings before writing |
+| Oversized file / diff DoS | read_file streams and caps lines/bytes even for a single huge line; git_diff paginates with hard caps; search caps files/matches and runs fallback regexes in a terminable worker |
+| Tunnel exposure | Bridge binds 127.0.0.1 only (refuses 0.0.0.0); the only public surface is HTTPS via the tunnel, protected by OAuth; `/health` exposes only a random per-run identifier |
+| Admin API abuse | Loopback-only + workspace-isolated random admin token + one active bridge per workspace; proxy-marked requests are rejected and unauthenticated probes get 404 |
+| Log credential leakage/forgery | Logger redacts credentials and encodes CR/LF/control characters before writing one physical record |
 | Prompt injection via repo | Tool descriptions state content is untrusted data; the bridge grants no additional authority regardless of content; ChatGPT has zero write/exec capability |
 
 ## Token & scope design
@@ -39,14 +39,17 @@ Access tokens: 1 hour. Refresh tokens: 30 days, rotated. All tokens bound to
 
 ## Storage
 
-State lives under the OS-convention app dir
-(`~/Library/Application Support/codex-with-chatgpt` on macOS), directories 0700,
-files 0600. Only SHA-256 hashes of tokens are persisted — a stolen state file
-does not yield usable bearer tokens.
+Logs and non-secret operational cache live under the OS-convention app dir.
+Authorization state, runtime discovery and the local admin credential live in
+the selected workspace's ignored `.c2c-local/` directory, which is denied by
+all workspace read/list/search/diff/status tools. This prevents one sandboxed
+workspace from changing another workspace's security state. Files are written
+with owner-only permissions where the operating system supports them. Only
+SHA-256 hashes of access/refresh tokens are persisted.
 
 **V1 limitation**: client registrations and token hashes are file-based rather
-than OS-keychain-based. Raw tokens are never written anywhere. Keychain
-integration is a V2 item.
+than OS-keychain-based. Raw access/refresh tokens are never written anywhere.
+Keychain integration is a V2 item.
 
 ## What ChatGPT can never do (V1)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,7 +56,7 @@ Linux: see Cloudflare's package instructions.
 The Skill installs this automatically during setup.
 
 ### Every new Codex chat “repairs” the connection / cannot write logs
-The C2C state directory lives outside the project (macOS:
+The C2C logs and non-secret operational cache live outside the project (macOS:
 `~/Library/Application Support/codex-with-chatgpt`; Windows:
 `%LOCALAPPDATA%\codex-with-chatgpt`). Codex's default sandbox cannot write
 there, so each new chat looks like a health-check failure.
@@ -65,6 +65,10 @@ there, so each new chat looks like a health-check failure.
 `[sandbox_workspace_write].writable_roots` in `~/.codex/config.toml`
 (`%USERPROFILE%\.codex\config.toml` on Windows). After that, later chats
 do not need elevation.
+
+Security-bearing connection state is isolated inside the selected workspace's
+hidden, ignored `.c2c-local/` directory. C2C never exposes that directory to
+ChatGPT's workspace tools.
 
 ### Port already in use
 Handled automatically: an existing healthy bridge for the same workspace is

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -132,7 +132,7 @@ At the START of every workflow below (before anything else), run these two
 commands (both are cheap / cached; never mention them unless an update exists):
 
 1. `c2c update-check --json`
-2. `c2c sandbox-allow --json` — writes the C2C state directory into Codex's
+2. `c2c sandbox-allow --json` — writes the C2C non-secret operational state directory into Codex's
    sandbox `writable_roots` (macOS: `~/Library/Application Support/codex-with-chatgpt`;
    Windows: `%LOCALAPPDATA%\codex-with-chatgpt`; config file is
    `~/.codex/config.toml` on both, or `%USERPROFILE%\.codex\config.toml` on Windows).
@@ -165,7 +165,7 @@ Inside the checkout directory (see Locations):
      `winget install Cloudflare.cloudflared`. Do this yourself; don't ask.
 2. If the c2c repo has no `node_modules`, run `pnpm install && pnpm build` in it.
 3. Run: `c2c sandbox-allow --json` then `c2c setup -w <workspace> --json`.
-   `sandbox-allow` edits Codex `config.toml` only — it adds C2C's state directory
+   `sandbox-allow` edits Codex `config.toml` only — it adds C2C's non-secret operational state directory
    to `[sandbox_workspace_write].writable_roots` so later chats can write logs
    without elevation. If the write is denied, request approval and retry once.
    → returns `{ mcpUrl, pairingCode, workspaceName, connectorName, ... }`.

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -22,6 +22,27 @@ interface PendingAuthRequest {
   codeChallenge: string;
   resource?: string;
   expiresAt: number;
+  clientName: string;
+  redirectOrigin: string;
+  attemptsLeft: number;
+}
+
+const MAX_PENDING_REQUESTS = 128;
+const MAX_REDIRECT_URIS = 4;
+const MAX_REDIRECT_URI_LENGTH = 2048;
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[char] ?? char);
+}
+
+function singleString(value: unknown, maxLength: number): string | undefined {
+  return typeof value === "string" && value.length <= maxLength ? value : undefined;
 }
 
 function isAllowedRedirectUri(uri: string): boolean {
@@ -31,7 +52,13 @@ function isAllowedRedirectUri(uri: string): boolean {
   } catch {
     return false;
   }
-  if (parsed.protocol === "https:") return true;
+  if (
+    parsed.protocol === "https:" &&
+    parsed.hostname === "chatgpt.com" &&
+    parsed.username === "" &&
+    parsed.password === "" &&
+    /^\/connector\/oauth\/[A-Za-z0-9_-]+$/.test(parsed.pathname)
+  ) return true;
   if (parsed.protocol === "http:" && (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1")) {
     return true;
   }
@@ -68,6 +95,8 @@ function pairingPage(opts: {
   requestId: string;
   workspaceName: string;
   scopes: string[];
+  clientName: string;
+  redirectOrigin: string;
   error?: string;
 }): string {
   const scopeLabels: Record<string, string> = {
@@ -78,10 +107,10 @@ function pairingPage(opts: {
     offline_access: "Stay connected between sessions",
   };
   const scopeList = opts.scopes
-    .map((scope) => `<li>${scopeLabels[scope] ?? scope}</li>`)
+    .map((scope) => `<li>${escapeHtml(scopeLabels[scope] ?? scope)}</li>`)
     .join("");
   const errorHtml = opts.error
-    ? `<p class="error" role="alert">${opts.error}</p>`
+    ? `<p class="error" role="alert">${escapeHtml(opts.error)}</p>`
     : "";
   return `<!doctype html>
 <html lang="en">
@@ -115,10 +144,10 @@ function pairingPage(opts: {
 <body>
 <div class="card">
   <h1>${PRODUCT_NAME}</h1>
-  <p class="sub">ChatGPT is requesting access to workspace <strong>${opts.workspaceName}</strong> (read-only):</p>
+  <p class="sub"><strong>${escapeHtml(opts.clientName)}</strong> at ${escapeHtml(opts.redirectOrigin)} is requesting read-only access to workspace <strong>${escapeHtml(opts.workspaceName)}</strong>:</p>
   <ul>${scopeList}</ul>
   <form method="POST" action="authorize">
-    <input type="hidden" name="request_id" value="${opts.requestId}">
+    <input type="hidden" name="request_id" value="${escapeHtml(opts.requestId)}">
     <input type="text" name="pairing_code" id="pairing_code" placeholder="XXXX-XXXX"
            autocomplete="one-time-code" autofocus maxlength="9" required>
     ${errorHtml}
@@ -130,9 +159,42 @@ function pairingPage(opts: {
 </html>`;
 }
 
+function sendPairingPage(res: Response, opts: Parameters<typeof pairingPage>[0], status = 200): void {
+  res
+    .status(status)
+    .set(
+      "Content-Security-Policy",
+      `default-src 'none'; style-src 'unsafe-inline'; form-action 'self' ${opts.redirectOrigin}; base-uri 'none'; frame-ancestors 'none'`
+    )
+    .set("Referrer-Policy", "no-referrer")
+    .set("X-Content-Type-Options", "nosniff")
+    .type("html")
+    .send(pairingPage(opts));
+}
+
 export function createOAuthRouter(deps: OAuthDeps): Router {
   const router = Router();
   const pendingRequests = new Map<string, PendingAuthRequest>();
+  const routeHits = new Map<string, { count: number; resetAt: number }>();
+
+  const allowRequest = (req: Request, res: Response, bucket: string, limit: number): boolean => {
+    const forwarded = req.headers["cf-connecting-ip"];
+    const address = (Array.isArray(forwarded) ? forwarded[0] : forwarded) ?? req.ip ?? "unknown";
+    const key = `${bucket}:${address}`;
+    const now = Date.now();
+    const hit = routeHits.get(key);
+    if (!hit || now > hit.resetAt) {
+      routeHits.set(key, { count: 1, resetAt: now + 60_000 });
+    } else {
+      hit.count++;
+      if (hit.count > limit) {
+        res.status(429).json({ error: "rate_limited" });
+        return false;
+      }
+    }
+    while (routeHits.size > 1024) routeHits.delete(routeHits.keys().next().value as string);
+    return true;
+  };
 
   const prunePending = (): void => {
     const now = Date.now();
@@ -157,23 +219,42 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
 
   // ---- Dynamic Client Registration (RFC 7591) ------------------------------
 
-  router.post("/oauth/register", json(), (req, res) => {
-    const body = req.body as { client_name?: string; redirect_uris?: unknown };
+  router.post(
+    "/oauth/register",
+    (req, res, next) => { if (allowRequest(req, res, "register", 20)) next(); },
+    json({ limit: "16kb", strict: true }),
+    (req, res) => {
+    const body = (req.body && typeof req.body === "object" ? req.body : {}) as {
+      client_name?: string;
+      redirect_uris?: unknown;
+    };
     const redirectUris = Array.isArray(body.redirect_uris) ? body.redirect_uris : [];
     if (
       redirectUris.length === 0 ||
-      !redirectUris.every((uri) => typeof uri === "string" && isAllowedRedirectUri(uri))
+      redirectUris.length > MAX_REDIRECT_URIS ||
+      !redirectUris.every(
+        (uri) =>
+          typeof uri === "string" &&
+          uri.length <= MAX_REDIRECT_URI_LENGTH &&
+          isAllowedRedirectUri(uri)
+      )
     ) {
       res.status(400).json({
         error: "invalid_redirect_uri",
-        error_description: "redirect_uris must be https URLs (or http://localhost for development)",
+        error_description: "redirect_uris must be ChatGPT connector URLs (or localhost for development)",
       });
       return;
     }
-    const client = deps.store.registerClient({
-      clientName: typeof body.client_name === "string" ? body.client_name.slice(0, 200) : undefined,
-      redirectUris: redirectUris as string[],
-    });
+    let client;
+    try {
+      client = deps.store.registerClient({
+        clientName: typeof body.client_name === "string" ? body.client_name.slice(0, 200) : undefined,
+        redirectUris: redirectUris as string[],
+      });
+    } catch {
+      res.status(429).json({ error: "temporarily_unavailable" });
+      return;
+    }
     deps.logger.info(`Registered OAuth client ${client.clientId} (${client.clientName ?? "unnamed"})`);
     res.status(201).json({
       client_id: client.clientId,
@@ -183,20 +264,32 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
     });
-  });
+    }
+  );
 
   // ---- Authorization endpoint ----------------------------------------------
 
   router.get("/oauth/authorize", (req, res) => {
+    if (!allowRequest(req, res, "authorize", 60)) return;
     prunePending();
-    const query = req.query as Record<string, string | undefined>;
+    const raw = req.query as Record<string, unknown>;
+    const query = {
+      client_id: singleString(raw.client_id, 256),
+      redirect_uri: singleString(raw.redirect_uri, MAX_REDIRECT_URI_LENGTH),
+      response_type: singleString(raw.response_type, 32),
+      state: singleString(raw.state, 2048),
+      code_challenge: singleString(raw.code_challenge, 128),
+      code_challenge_method: singleString(raw.code_challenge_method, 16),
+      scope: singleString(raw.scope, 1024),
+      resource: singleString(raw.resource, MAX_REDIRECT_URI_LENGTH),
+    };
     const client = query.client_id ? deps.store.getClient(query.client_id) : undefined;
     if (!client) {
       res.status(400).send("Unknown client. Please reconnect from ChatGPT.");
       return;
     }
     const redirectUri = query.redirect_uri;
-    if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
+    if (!redirectUri || !isAllowedRedirectUri(redirectUri) || !client.redirectUris.includes(redirectUri)) {
       res.status(400).send("Invalid redirect_uri.");
       return;
     }
@@ -215,6 +308,19 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       fail("invalid_request", "PKCE with S256 is required");
       return;
     }
+    if (!/^[A-Za-z0-9_-]{43,128}$/.test(query.code_challenge)) {
+      fail("invalid_request", "Invalid PKCE challenge");
+      return;
+    }
+    const expectedResource = `${deps.getBaseUrl(req)}/mcp`;
+    if (query.resource && query.resource !== expectedResource) {
+      fail("invalid_target", "Invalid resource");
+      return;
+    }
+    if (pendingRequests.size >= MAX_PENDING_REQUESTS) {
+      res.status(429).send("Too many pending authorization requests. Please try again shortly.");
+      return;
+    }
     const scopes = filterScopes(query.scope);
     const request: PendingAuthRequest = {
       id: randomBytes(16).toString("hex"),
@@ -225,15 +331,25 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       codeChallenge: query.code_challenge,
       resource: query.resource,
       expiresAt: Date.now() + 10 * 60_000,
+      clientName: client.clientName?.trim().slice(0, 200) || "ChatGPT connector",
+      redirectOrigin: new URL(redirectUri).origin,
+      attemptsLeft: 5,
     };
     pendingRequests.set(request.id, request);
-    res
-      .status(200)
-      .type("html")
-      .send(pairingPage({ requestId: request.id, workspaceName: deps.workspaceName, scopes }));
+    sendPairingPage(res, {
+      requestId: request.id,
+      workspaceName: deps.workspaceName,
+      scopes,
+      clientName: request.clientName,
+      redirectOrigin: request.redirectOrigin,
+    });
   });
 
-  router.post("/oauth/authorize", urlencoded({ extended: false }), (req, res) => {
+  router.post(
+    "/oauth/authorize",
+    (req, res, next) => { if (allowRequest(req, res, "verify", 30)) next(); },
+    urlencoded({ extended: false, limit: "4kb" }),
+    (req, res) => {
     prunePending();
     const body = req.body as { request_id?: string; pairing_code?: string };
     const request = body.request_id ? pendingRequests.get(body.request_id) : undefined;
@@ -241,27 +357,39 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       res.status(400).send("This authorization request has expired. Please reconnect from ChatGPT.");
       return;
     }
-    const verdict = deps.pairing.verify(body.pairing_code ?? "", req.ip);
+    const verdict = deps.pairing.verify(body.pairing_code ?? "", req.ip, { consumeFailure: false });
     if (!verdict.ok) {
+      if (verdict.reason === "invalid") {
+        request.attemptsLeft--;
+        if (request.attemptsLeft <= 0) {
+          pendingRequests.delete(request.id);
+          sendPairingPage(res, {
+            requestId: request.id,
+            workspaceName: deps.workspaceName,
+            scopes: request.scopes,
+            clientName: request.clientName,
+            redirectOrigin: request.redirectOrigin,
+            error: "Too many incorrect attempts. Restart the connection from ChatGPT.",
+          }, 410);
+          return;
+        }
+      }
       const messages: Record<string, string> = {
-        invalid: `Incorrect pairing code.${verdict.attemptsLeft !== undefined ? ` ${verdict.attemptsLeft} attempts left.` : ""}`,
+        invalid: `Incorrect pairing code. ${request.attemptsLeft} attempts left.`,
         expired: "This pairing code has expired. Ask Codex to generate a new one.",
         too_many_attempts: "Too many incorrect attempts. Ask Codex to generate a new pairing code.",
         rate_limited: "Too many attempts. Please wait a minute and try again.",
         no_active_session: "No active pairing session. Ask Codex to generate a pairing code.",
       };
       deps.logger.warn(`Pairing verification failed: ${verdict.reason}`);
-      res
-        .status(verdict.reason === "invalid" ? 401 : 410)
-        .type("html")
-        .send(
-          pairingPage({
-            requestId: request.id,
-            workspaceName: deps.workspaceName,
-            scopes: request.scopes,
-            error: messages[verdict.reason] ?? "Verification failed.",
-          })
-        );
+      sendPairingPage(res, {
+        requestId: request.id,
+        workspaceName: deps.workspaceName,
+        scopes: request.scopes,
+        clientName: request.clientName,
+        redirectOrigin: request.redirectOrigin,
+        error: messages[verdict.reason] ?? "Verification failed.",
+      }, verdict.reason === "invalid" ? 401 : 410);
       return;
     }
     pendingRequests.delete(request.id);
@@ -278,12 +406,18 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     url.searchParams.set("code", code);
     if (request.state) url.searchParams.set("state", request.state);
     res.redirect(url.toString());
-  });
+    }
+  );
 
   // ---- Token endpoint --------------------------------------------------------
 
-  router.post("/oauth/token", urlencoded({ extended: false }), json(), (req, res) => {
-    const body = req.body as Record<string, string | undefined>;
+  router.post(
+    "/oauth/token",
+    (req, res, next) => { if (allowRequest(req, res, "token", 120)) next(); },
+    urlencoded({ extended: false, limit: "16kb" }),
+    json({ limit: "16kb" }),
+    (req, res) => {
+    const body = (req.body && typeof req.body === "object" ? req.body : {}) as Record<string, string | undefined>;
     const grantType = body.grant_type;
 
     if (grantType === "authorization_code") {
@@ -340,11 +474,12 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     }
 
     res.status(400).json({ error: "unsupported_grant_type" });
-  });
+    }
+  );
 
   // ---- Revocation (RFC 7009) ---------------------------------------------------
 
-  router.post("/oauth/revoke", urlencoded({ extended: false }), (req, res) => {
+  router.post("/oauth/revoke", urlencoded({ extended: false, limit: "16kb" }), (req, res) => {
     const body = req.body as { token?: string };
     if (body.token) deps.store.revokeToken(body.token);
     res.status(200).json({});

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { ensureDir, getStateDir, readJsonIfExists, writeSecureJson } from "../config/paths.js";
+import { workspaceStateFile } from "../workspace/local-state.js";
 
 export const SUPPORTED_SCOPES = [
   "workspace.read",
@@ -55,6 +56,9 @@ export type VerifyTokenResult =
 const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
 const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const AUTH_CODE_TTL_MS = 5 * 60 * 1000;
+const MAX_CLIENTS = 64;
+const MAX_TOKENS = 512;
+const MAX_AUTH_CODES = 128;
 
 function sha256hex(value: string): string {
   return createHash("sha256").update(value).digest("hex");
@@ -84,20 +88,64 @@ export class AuthStore {
 
   constructor(
     readonly workspaceId: string,
-    opts: { file?: string } = {}
+    opts: { file?: string; workspaceRoot?: string } = {}
   ) {
-    this.file =
-      opts.file ?? path.join(ensureDir(path.join(getStateDir(), "auth")), `${workspaceId}.json`);
+    if (opts.file) {
+      this.file = opts.file;
+    } else if (opts.workspaceRoot) {
+      this.file = workspaceStateFile(opts.workspaceRoot, "auth.json");
+      this.migrateLegacyState();
+    } else {
+      throw new Error("AuthStore requires workspaceRoot when no explicit test file is supplied");
+    }
     this.load();
+  }
+
+  private migrateLegacyState(): void {
+    if (fs.existsSync(this.file)) return;
+    const legacy = path.join(ensureDir(path.join(getStateDir(), "auth")), `${this.workspaceId}.json`);
+    if (!fs.existsSync(legacy)) return;
+    try {
+      const data = readJsonIfExists<PersistedAuthState>(legacy);
+      if (data) writeSecureJson(this.file, data);
+      fs.rmSync(legacy, { force: true });
+    } catch {
+      // A failed migration leaves the old state untouched for manual recovery.
+    }
   }
 
   private load(): void {
     const data = readJsonIfExists<PersistedAuthState>(this.file);
     if (!data) return;
     const now = Date.now();
-    for (const client of data.clients ?? []) this.clients.set(client.clientId, client);
-    for (const token of data.tokens ?? []) {
-      if (!token.revoked && token.expiresAt > now) this.tokens.set(token.hash, token);
+    const clients = Array.isArray(data.clients) ? data.clients : [];
+    const tokens = Array.isArray(data.tokens) ? data.tokens : [];
+    for (const client of clients.slice(-MAX_CLIENTS)) {
+      if (
+        client &&
+        typeof client.clientId === "string" &&
+        client.clientId.startsWith("c2c_client_") &&
+        Array.isArray(client.redirectUris) &&
+        client.redirectUris.length <= 4 &&
+        client.redirectUris.every((uri) => typeof uri === "string" && uri.length <= 2048)
+      ) {
+        this.clients.set(client.clientId, client);
+      }
+    }
+    for (const token of tokens.slice(-MAX_TOKENS)) {
+      if (
+        token &&
+        typeof token.hash === "string" &&
+        /^[a-f0-9]{64}$/.test(token.hash) &&
+        (token.kind === "access" || token.kind === "refresh") &&
+        token.workspaceId === this.workspaceId &&
+        Array.isArray(token.scopes) &&
+        !token.revoked &&
+        typeof token.expiresAt === "number" &&
+        token.expiresAt > now
+      ) {
+        this.tokens.set(token.hash, token);
+      }
     }
   }
 
@@ -113,6 +161,14 @@ export class AuthStore {
   // ---- Dynamic Client Registration -------------------------------------
 
   registerClient(input: { clientName?: string; redirectUris: string[] }): ClientRegistration {
+    if (this.clients.size >= MAX_CLIENTS) {
+      const referenced = new Set([...this.tokens.values()].map((token) => token.clientId));
+      const evictable = [...this.clients.values()]
+        .filter((client) => !referenced.has(client.clientId))
+        .sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0];
+      if (!evictable) throw new Error("OAuth client capacity reached");
+      this.clients.delete(evictable.clientId);
+    }
     const client: ClientRegistration = {
       clientId: `c2c_client_${randomBytes(12).toString("base64url")}`,
       clientName: input.clientName,
@@ -138,6 +194,15 @@ export class AuthStore {
     pairingSessionId: string;
     resource?: string;
   }): string {
+    const now = Date.now();
+    for (const [existingCode, record] of this.authCodes) {
+      if (record.expiresAt <= now) this.authCodes.delete(existingCode);
+    }
+    while (this.authCodes.size >= MAX_AUTH_CODES) {
+      const oldest = this.authCodes.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.authCodes.delete(oldest);
+    }
     const code = newToken("c2c_ac");
     this.authCodes.set(code, {
       code,
@@ -171,6 +236,12 @@ export class AuthStore {
     accessTtlMs?: number;
   }): { accessToken: string; refreshToken: string | null; expiresIn: number; scopes: string[] } {
     const now = Date.now();
+    for (const [hash, token] of this.tokens) {
+      if (token.revoked || token.expiresAt <= now) this.tokens.delete(hash);
+    }
+    if (this.tokens.size + (input.scopes.includes("offline_access") ? 2 : 1) > MAX_TOKENS) {
+      throw new Error("OAuth token capacity reached");
+    }
     const workspaceId = input.workspaceId ?? this.workspaceId;
     const accessTtl = input.accessTtlMs ?? ACCESS_TOKEN_TTL_MS;
 
@@ -260,8 +331,10 @@ export class AuthStore {
     return this.tokens.size;
   }
 
-  static deleteStateFile(workspaceId: string): void {
-    const file = path.join(getStateDir(), "auth", `${workspaceId}.json`);
+  static deleteStateFile(workspaceId: string, workspaceRoot?: string): void {
+    const file = workspaceRoot
+      ? workspaceStateFile(workspaceRoot, "auth.json")
+      : path.join(getStateDir(), "auth", `${workspaceId}.json`);
     try {
       fs.rmSync(file, { force: true });
     } catch {

--- a/src/bridge/runtime.ts
+++ b/src/bridge/runtime.ts
@@ -1,49 +1,59 @@
 import fs from "node:fs";
 import path from "node:path";
-import { ensureDir, getStateDir, readJsonIfExists, writeSecureJson } from "../config/paths.js";
+import { getStateDir, readJsonIfExists } from "../config/paths.js";
 import { SERVICE_NAME, VERSION } from "../version.js";
+import {
+  removeWorkspaceStateFile,
+  workspaceStateFile,
+  writeWorkspaceStateJson,
+} from "../workspace/local-state.js";
 
 /**
  * Runtime state file: how the CLI/Skill finds a running bridge for a
- * workspace. Contains the admin token, so it is 0600 and lives in the user
- * state dir, never in the project.
+ * workspace. Credentials are deliberately kept out of this discoverable file.
  */
 export interface RuntimeState {
   service: string;
   version: string;
   workspaceId: string;
   workspaceRoot: string;
+  instanceId: string;
   pid: number;
   port: number;
-  adminToken: string;
+  /** Legacy compatibility only. New runtime files never persist this value. */
+  adminToken?: string;
   publicUrl: string | null;
   startedAt: string;
 }
 
-export function runtimeFile(workspaceId: string): string {
-  return path.join(ensureDir(path.join(getStateDir(), "runtime")), `${workspaceId}.json`);
+export function runtimeFile(workspaceRoot: string): string {
+  return workspaceStateFile(workspaceRoot, "runtime.json");
 }
 
 export function writeRuntimeState(state: RuntimeState): void {
-  writeSecureJson(runtimeFile(state.workspaceId), state);
-}
-
-export function readRuntimeState(workspaceId: string): RuntimeState | null {
-  return readJsonIfExists<RuntimeState>(runtimeFile(workspaceId));
-}
-
-export function clearRuntimeState(workspaceId: string): void {
+  const { adminToken: _legacySecret, ...safeState } = state;
+  writeWorkspaceStateJson(state.workspaceRoot, "runtime.json", safeState);
   try {
-    fs.rmSync(runtimeFile(workspaceId), { force: true });
+    fs.rmSync(path.join(getStateDir(), "runtime", `${state.workspaceId}.json`), { force: true });
   } catch {
-    // ignore
+    // best effort cleanup of the exact legacy runtime file
   }
+}
+
+export function readRuntimeState(workspaceRoot: string): RuntimeState | null {
+  return readJsonIfExists<RuntimeState>(runtimeFile(workspaceRoot));
+}
+
+export function clearRuntimeState(workspaceRoot: string): void {
+  removeWorkspaceStateFile(workspaceRoot, "runtime.json");
 }
 
 export interface HealthPayload {
   service: string;
   version: string;
-  workspaceId: string;
+  instanceId?: string;
+  /** Legacy bridge compatibility only. */
+  workspaceId?: string;
   status: string;
 }
 
@@ -66,11 +76,17 @@ export async function probeBridge(
   }
 }
 
-export async function findLiveBridge(workspaceId: string): Promise<RuntimeState | null> {
-  const state = readRuntimeState(workspaceId);
+export async function findLiveBridge(workspaceRoot: string, workspaceId: string): Promise<RuntimeState | null> {
+  const state = readRuntimeState(workspaceRoot);
   if (!state) return null;
+  if (state.workspaceId !== workspaceId || state.workspaceRoot !== workspaceRoot) return null;
   const health = await probeBridge(state.port);
-  if (health && health.workspaceId === workspaceId) return state;
+  if (
+    health &&
+    (state.instanceId
+      ? health.instanceId === state.instanceId
+      : health.workspaceId === workspaceId)
+  ) return state;
   return null;
 }
 

--- a/src/bridge/server.ts
+++ b/src/bridge/server.ts
@@ -13,7 +13,12 @@ import type { TunnelProvider } from "../tunnel/provider.js";
 import { Logger, nullLogger } from "../logger/index.js";
 import { DEFAULT_HOST, DEFAULT_PORT } from "../config/paths.js";
 import { SERVICE_NAME, VERSION } from "../version.js";
-import { writeRuntimeState, clearRuntimeState, type RuntimeState } from "./runtime.js";
+import { writeRuntimeState, clearRuntimeState, findLiveBridge, type RuntimeState } from "./runtime.js";
+import {
+  acquireWorkspaceBridgeLock,
+  removeWorkspaceStateFile,
+  writeWorkspaceStateText,
+} from "../workspace/local-state.js";
 
 export interface BridgeOptions {
   workspaceRoot: string;
@@ -73,10 +78,18 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
     throw new Error("The bridge only binds to loopback addresses. Public exposure goes through the tunnel.");
   }
 
-  const authStore = new AuthStore(workspace.id, { file: opts.authStoreFile });
+  const authStore = new AuthStore(workspace.id, {
+    file: opts.authStoreFile,
+    workspaceRoot: workspace.root,
+  });
   const pairing = new PairingManager(workspace.id, { ttlMs: opts.pairingTtlMs });
   const tunnel = opts.tunnelProvider ?? new CloudflaredQuickTunnel(logger);
   const adminToken = `c2c_admin_${randomBytes(24).toString("base64url")}`;
+  const instanceId = randomBytes(16).toString("hex");
+
+  if (opts.persistRuntime !== false && await findLiveBridge(workspace.root, workspace.id)) {
+    throw new Error("A C2C bridge is already active for this workspace");
+  }
 
   let publicBaseUrl: string | null = null;
 
@@ -94,7 +107,7 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
   // ---- Health (public but minimal) ---------------------------------------
 
   app.get("/health", (_req, res) => {
-    res.json({ service: SERVICE_NAME, version: VERSION, workspaceId: workspace.id, status: "ok" });
+    res.json({ service: SERVICE_NAME, version: VERSION, instanceId, status: "ok" });
   });
 
   // ---- OAuth + discovery ---------------------------------------------------
@@ -114,8 +127,8 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
   const mcpHandler = createMcpHttpHandler(() => createMcpServer({ workspace, logger }), logger);
   app.all(
     "/mcp",
-    express.json({ limit: "8mb" }),
     bearerAuth({ store: authStore, workspaceId: workspace.id, getBaseUrl, logger }),
+    express.json({ limit: "8mb" }),
     (req: Request, res: Response) => {
       void mcpHandler(req, res);
     }
@@ -196,7 +209,20 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
     }, 100);
   });
 
-  const { server, port } = await listen(app, host, opts.port ?? DEFAULT_PORT);
+  const releaseBridgeLock =
+    opts.persistRuntime === false ? () => undefined : acquireWorkspaceBridgeLock(workspace.root, instanceId);
+  let server: Server;
+  let port: number;
+  try {
+    if (opts.persistRuntime !== false) {
+      writeWorkspaceStateText(workspace.root, "admin-token", adminToken);
+    }
+    ({ server, port } = await listen(app, host, opts.port ?? DEFAULT_PORT));
+  } catch (error) {
+    if (opts.persistRuntime !== false) removeWorkspaceStateFile(workspace.root, "admin-token");
+    releaseBridgeLock();
+    throw error;
+  }
   const startedAt = new Date().toISOString();
   logger.info(`Bridge listening on ${host}:${port} for workspace ${workspace.name} (${workspace.id})`);
 
@@ -207,15 +233,22 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
       version: VERSION,
       workspaceId: workspace.id,
       workspaceRoot: workspace.root,
+      instanceId,
       pid: process.pid,
       port,
-      adminToken,
       publicUrl: publicBaseUrl,
       startedAt,
     };
     writeRuntimeState(state);
   };
-  persistRuntime();
+  try {
+    persistRuntime();
+  } catch (error) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (opts.persistRuntime !== false) removeWorkspaceStateFile(workspace.root, "admin-token");
+    releaseBridgeLock();
+    throw error;
+  }
 
   let closed = false;
   const shutdown = async (): Promise<void> => {
@@ -223,7 +256,11 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
     closed = true;
     await tunnel.stop().catch(() => undefined);
     await new Promise<void>((resolve) => server.close(() => resolve()));
-    if (opts.persistRuntime !== false) clearRuntimeState(workspace.id);
+    if (opts.persistRuntime !== false) {
+      clearRuntimeState(workspace.root);
+      removeWorkspaceStateFile(workspace.root, "admin-token");
+      releaseBridgeLock();
+    }
     logger.info("Bridge stopped");
   };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import {
   type LastEndpoint,
 } from "../config/endpoint.js";
 import { PRODUCT_NAME, VERSION } from "../version.js";
+import { findTrustedExecutable } from "../process/executable.js";
 
 const program = new Command();
 
@@ -286,7 +287,7 @@ program
   .action(async (opts: { workspace?: string; json: boolean }) => {
     const root = resolveWorkspace(opts.workspace);
     const workspace = new Workspace(root);
-    const runtime = await findLiveBridge(workspace.id);
+    const runtime = await findLiveBridge(workspace.root, workspace.id);
     if (!runtime) {
       if (opts.json) say(JSON.stringify({ ok: false, running: false }));
       else say("Bridge 未运行。使用 `c2c start` 启动。");
@@ -355,7 +356,7 @@ program
     // Bridge
     let runtime: RuntimeState | null = null;
     if (workspace) {
-      runtime = await findLiveBridge(workspace.id);
+      runtime = await findLiveBridge(workspace.root, workspace.id);
       if (!runtime && opts.fix) {
         try {
           runtime = (await ensureBridge(root)).runtime;
@@ -582,12 +583,12 @@ program
   .action(async (opts: { workspace?: string }) => {
     const root = resolveWorkspace(opts.workspace);
     const workspace = new Workspace(root);
-    const runtime = await findLiveBridge(workspace.id);
+    const runtime = await findLiveBridge(workspace.root, workspace.id);
     if (runtime) {
       await adminFetch(runtime, "POST", "/admin/revoke-all");
     } else {
       // bridge not running: revoke directly in the persisted store
-      new AuthStore(workspace.id).revokeAll();
+      new AuthStore(workspace.id, { workspaceRoot: workspace.root }).revokeAll();
     }
     check("已断开 ChatGPT 对当前项目的访问（所有令牌已吊销）");
   });
@@ -661,7 +662,9 @@ program
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 function runGit(args: string[]): { ok: boolean; stdout: string } {
-  const result = spawnSync("git", args, {
+  const git = findTrustedExecutable("git", { forbiddenRoots: [repoRoot] });
+  if (!git) return { ok: false, stdout: "" };
+  const result = spawnSync(git, args, {
     cwd: repoRoot,
     encoding: "utf8",
     timeout: 8000,

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -23,6 +23,13 @@ export function redact(input: string): string {
   return out;
 }
 
+function oneLogLine(input: string): string {
+  return redact(input)
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "?");
+}
+
 export interface LoggerOptions {
   name?: string;
   level?: LogLevel;
@@ -50,10 +57,10 @@ export class Logger {
 
   private write(level: LogLevel, msg: string, extra?: unknown): void {
     if (LEVELS[level] < this.level) return;
-    const parts = [new Date().toISOString(), level.toUpperCase().padEnd(5), `[${this.name}]`, redact(msg)];
+    const parts = [new Date().toISOString(), level.toUpperCase().padEnd(5), `[${oneLogLine(this.name)}]`, oneLogLine(msg)];
     if (extra !== undefined) {
       try {
-        parts.push(redact(JSON.stringify(extra)));
+        parts.push(oneLogLine(JSON.stringify(extra)));
       } catch {
         parts.push("[unserializable]");
       }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -179,7 +179,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "git.read");
       if (denied) return denied;
       try {
-        return ok(gitStatus(workspace.root));
+        return ok(gitStatus(workspace));
       } catch (error) {
         return mapError(error);
       }

--- a/src/pairing/manager.ts
+++ b/src/pairing/manager.ts
@@ -111,7 +111,11 @@ export class PairingManager {
     return entry.count <= this.ipRateLimit;
   }
 
-  verify(codeInput: string, ip?: string): PairingVerifyResult {
+  verify(
+    codeInput: string,
+    ip?: string,
+    opts: { consumeFailure?: boolean } = {}
+  ): PairingVerifyResult {
     if (!this.checkIpRate(ip)) {
       return { ok: false, reason: "rate_limited" };
     }
@@ -137,6 +141,9 @@ export class PairingManager {
         session.used = true;
         this.sessions.delete(session.id);
         return { ok: true, sessionId: session.id };
+      }
+      if (opts.consumeFailure === false) {
+        return { ok: false, reason: "invalid" };
       }
       session.attemptsLeft--;
       if (session.attemptsLeft <= 0) {

--- a/src/process/daemon.ts
+++ b/src/process/daemon.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { ensureDir, getStateDir } from "../config/paths.js";
 import { findLiveBridge, probeBridge, readRuntimeState, type RuntimeState } from "../bridge/runtime.js";
 import { Workspace } from "../workspace/manager.js";
+import { workspaceStateFile } from "../workspace/local-state.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -31,7 +32,7 @@ export interface EnsureBridgeResult {
  */
 export async function ensureBridge(workspaceRoot: string, opts: { port?: number } = {}): Promise<EnsureBridgeResult> {
   const workspace = new Workspace(workspaceRoot);
-  const live = await findLiveBridge(workspace.id);
+  const live = await findLiveBridge(workspace.root, workspace.id);
   if (live) return { runtime: live, spawned: false };
 
   const logDir = ensureDir(path.join(getStateDir(), "logs"));
@@ -52,6 +53,7 @@ export async function ensureBridge(workspaceRoot: string, opts: { port?: number 
       detached: true,
       stdio: ["ignore", out, out],
       env: { ...process.env },
+      cwd: workspace.root,
     }
   );
   child.unref();
@@ -60,7 +62,7 @@ export async function ensureBridge(workspaceRoot: string, opts: { port?: number 
   const deadline = Date.now() + 20_000;
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 300));
-    const runtime = await findLiveBridge(workspace.id);
+    const runtime = await findLiveBridge(workspace.root, workspace.id);
     if (runtime) return { runtime, spawned: true };
     if (child.exitCode !== null && child.exitCode !== 0) {
       throw new Error(`Bridge process exited with code ${child.exitCode}. See ${logFile}`);
@@ -78,9 +80,11 @@ export async function adminFetch<T = unknown>(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    const adminToken =
+      runtime.adminToken ?? fs.readFileSync(workspaceStateFile(runtime.workspaceRoot, "admin-token"), "utf8").trim();
     const response = await fetch(`http://127.0.0.1:${runtime.port}${route}`, {
       method,
-      headers: { Authorization: `Bearer ${runtime.adminToken}` },
+      headers: { Authorization: `Bearer ${adminToken}` },
       signal: controller.signal,
     });
     const body = (await response.json().catch(() => ({}))) as T & { message?: string };
@@ -95,10 +99,15 @@ export async function adminFetch<T = unknown>(
 
 export async function stopBridge(workspaceRoot: string): Promise<boolean> {
   const workspace = new Workspace(workspaceRoot);
-  const runtime = readRuntimeState(workspace.id);
+  const runtime = readRuntimeState(workspace.root);
   if (!runtime) return false;
   const healthy = await probeBridge(runtime.port);
-  if (healthy && healthy.workspaceId === workspace.id) {
+  if (
+    healthy &&
+    (runtime.instanceId
+      ? healthy.instanceId === runtime.instanceId
+      : healthy.workspaceId === workspace.id)
+  ) {
     try {
       await adminFetch(runtime, "POST", "/admin/shutdown", 5000);
       return true;

--- a/src/process/executable.ts
+++ b/src/process/executable.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface ExecutableSearchOptions {
+  /** Absolute executable paths to try after PATH. */
+  additionalCandidates?: string[];
+  /** Absolute directories to search after PATH. */
+  additionalDirectories?: string[];
+  forbiddenRoots?: string[];
+  override?: string;
+  pathValue?: string;
+}
+
+const CASE_INSENSITIVE = process.platform === "win32" || process.platform === "darwin";
+
+function normalize(value: string): string {
+  const resolved = path.resolve(value);
+  return CASE_INSENSITIVE ? resolved.toLowerCase() : resolved;
+}
+
+function isInside(candidate: string, root: string): boolean {
+  const c = normalize(candidate);
+  const r = normalize(root);
+  return c === r || c.startsWith(r + path.sep);
+}
+
+function executableNames(name: string): string[] {
+  if (process.platform !== "win32" || path.extname(name)) return [name];
+  const extensions = (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  return extensions.map((extension) => `${name}${extension}`);
+}
+
+function trustedFile(candidate: string, forbiddenRoots: string[]): string | null {
+  if (!path.isAbsolute(candidate)) return null;
+  try {
+    const real = fs.realpathSync.native(candidate);
+    if (forbiddenRoots.some((root) => isInside(real, root))) return null;
+    const stat = fs.statSync(real);
+    if (!stat.isFile()) return null;
+    fs.accessSync(real, fs.constants.X_OK);
+    return real;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a helper without invoking the operating system's cwd-sensitive
+ * executable search. Relative and workspace-local candidates are ignored.
+ */
+export function findTrustedExecutable(name: string, opts: ExecutableSearchOptions = {}): string | null {
+  const forbiddenRoots = (opts.forbiddenRoots ?? []).map((root) => path.resolve(root));
+  const names = executableNames(name);
+  const candidates: string[] = [];
+
+  if (opts.override) candidates.push(opts.override);
+  for (const rawDir of (opts.pathValue ?? process.env.PATH ?? "").split(path.delimiter)) {
+    const dir = rawDir.trim().replace(/^"|"$/g, "");
+    if (!dir || !path.isAbsolute(dir)) continue;
+    for (const executable of names) candidates.push(path.join(dir, executable));
+  }
+  candidates.push(...(opts.additionalCandidates ?? []));
+  for (const dir of opts.additionalDirectories ?? []) {
+    if (!path.isAbsolute(dir)) continue;
+    for (const executable of names) candidates.push(path.join(dir, executable));
+  }
+
+  for (const candidate of candidates) {
+    const resolved = trustedFile(candidate, forbiddenRoots);
+    if (resolved) return resolved;
+  }
+  return null;
+}

--- a/src/tunnel/detect.ts
+++ b/src/tunnel/detect.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { findTrustedExecutable } from "../process/executable.js";
 
 const COMMON_DIRS = [
   "/opt/homebrew/bin",
@@ -13,25 +13,17 @@ const COMMON_DIRS = [
 
 /** Locate a binary on PATH or in common install locations. */
 export function findBinary(name: string): string | null {
-  const exe = process.platform === "win32" ? `${name}.exe` : name;
+  const executable = findTrustedExecutable(name, {
+    additionalDirectories: COMMON_DIRS,
+    forbiddenRoots: [process.cwd()],
+  });
+  if (!executable) return null;
   try {
-    const probe = spawnSync(exe, ["--version"], { stdio: "ignore", timeout: 5000 });
-    if (probe.status === 0 || probe.status === 1) return exe; // on PATH
+    const probe = spawnSync(executable, ["--version"], { stdio: "ignore", timeout: 5000 });
+    return probe.status === 0 || probe.status === 1 ? executable : null;
   } catch {
-    // not on PATH
+    return null;
   }
-  for (const dir of COMMON_DIRS) {
-    const full = path.join(dir, exe);
-    try {
-      if (fs.existsSync(full)) {
-        fs.accessSync(full, fs.constants.X_OK);
-        return full;
-      }
-    } catch {
-      // try next
-    }
-  }
-  return null;
 }
 
 export interface TunnelBinaries {

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { IgnoreRules } from "./ignore.js";
+import { findTrustedExecutable } from "../process/executable.js";
 
 export interface GitCommandResult {
   ok: boolean;
@@ -9,7 +10,11 @@ export interface GitCommandResult {
 }
 
 export function runGit(root: string, args: string[]): GitCommandResult {
-  const result = spawnSync("git", args, {
+  const git = findTrustedExecutable("git", { forbiddenRoots: [root] });
+  if (!git) {
+    return { ok: false, stdout: "", stderr: "Trusted git executable not found", code: null };
+  }
+  const result = spawnSync(git, args, {
     cwd: root,
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
@@ -60,7 +65,17 @@ export interface GitStatusResult {
   conflicted: string[];
 }
 
-export function gitStatus(root: string): GitStatusResult {
+export function gitStatus(target: GitTarget): GitStatusResult {
+  const root = typeof target === "string" ? target : target.root;
+  const ignoreRules =
+    typeof target === "object" && target.ignoreRules
+      ? target.ignoreRules
+      : new IgnoreRules(root);
+  const isSafe = (filePath: string): boolean =>
+    filePath
+      .split(" -> ")
+      .filter(Boolean)
+      .every((part) => !ignoreRules.isSensitive(part.replace(/^"|"$/g, "")));
   const empty: GitStatusResult = {
     isRepo: false,
     branch: null,
@@ -72,35 +87,48 @@ export function gitStatus(root: string): GitStatusResult {
     untracked: [],
     conflicted: [],
   };
-  const result = runGit(root, ["status", "--porcelain=v2", "--branch", "--", "."]);
+  const result = runGit(root, ["status", "--porcelain=v2", "-z", "--branch", "--", "."]);
   if (!result.ok) return empty;
   const out: GitStatusResult = { ...empty, isRepo: true };
-  for (const line of result.stdout.split("\n")) {
-    if (line.startsWith("# branch.head ")) {
-      out.branch = line.slice("# branch.head ".length).trim();
-    } else if (line.startsWith("# branch.upstream ")) {
-      out.upstream = line.slice("# branch.upstream ".length).trim();
-    } else if (line.startsWith("# branch.ab ")) {
-      const m = line.match(/\+(\d+) -(\d+)/);
+  const records = result.stdout.split("\0");
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index];
+    if (record.startsWith("# branch.head ")) {
+      out.branch = record.slice("# branch.head ".length).trim();
+    } else if (record.startsWith("# branch.upstream ")) {
+      out.upstream = record.slice("# branch.upstream ".length).trim();
+    } else if (record.startsWith("# branch.ab ")) {
+      const m = record.match(/\+(\d+) -(\d+)/);
       if (m) {
         out.ahead = parseInt(m[1], 10);
         out.behind = parseInt(m[2], 10);
       }
-    } else if (line.startsWith("1 ") || line.startsWith("2 ")) {
-      const parts = line.split(" ");
-      const xy = parts[1];
-      const filePath = line.startsWith("2 ")
-        ? line.split("\t")[0]?.split(" ").slice(9).join(" ") + " -> " + (line.split("\t")[1] ?? "")
-        : parts.slice(8).join(" ");
+    } else if (record.startsWith("1 ")) {
+      const match = /^1 ([^ ]{2}) (?:[^ ]+ ){6}([\s\S]*)$/.exec(record);
+      if (!match) continue;
+      const [, xy, filePath] = match;
       const x = xy[0];
       const y = xy[1];
-      if (x !== ".") out.staged.push({ path: filePath, change: x });
-      if (y !== ".") out.unstaged.push({ path: filePath, change: y });
-    } else if (line.startsWith("? ")) {
-      out.untracked.push(line.slice(2));
-    } else if (line.startsWith("u ")) {
-      const parts = line.split(" ");
-      out.conflicted.push(parts.slice(10).join(" "));
+      if (isSafe(filePath)) {
+        if (x !== ".") out.staged.push({ path: filePath, change: x });
+        if (y !== ".") out.unstaged.push({ path: filePath, change: y });
+      }
+    } else if (record.startsWith("2 ")) {
+      const match = /^2 ([^ ]{2}) (?:[^ ]+ ){7}([\s\S]*)$/.exec(record);
+      const oldPath = records[++index] ?? "";
+      if (!match) continue;
+      const [, xy, newPath] = match;
+      const filePath = `${oldPath} -> ${newPath}`;
+      if (isSafe(oldPath) && isSafe(newPath)) {
+        if (xy[0] !== ".") out.staged.push({ path: filePath, change: xy[0] });
+        if (xy[1] !== ".") out.unstaged.push({ path: filePath, change: xy[1] });
+      }
+    } else if (record.startsWith("? ")) {
+      const filePath = record.slice(2);
+      if (isSafe(filePath)) out.untracked.push(filePath);
+    } else if (record.startsWith("u ")) {
+      const match = /^u [^ ]{2} (?:[^ ]+ ){8}([\s\S]*)$/.exec(record);
+      if (match && isSafe(match[1])) out.conflicted.push(match[1]);
     }
   }
   return out;

--- a/src/workspace/ignore.ts
+++ b/src/workspace/ignore.ts
@@ -40,6 +40,7 @@ export const SENSITIVE_PATTERNS: string[] = [
   "cookies.sqlite",
   "Cookies",
   ".c2c-secrets*",
+  ".c2c-local/",
 ];
 
 /** High-noise directories excluded from listing/search by default. */

--- a/src/workspace/local-state.ts
+++ b/src/workspace/local-state.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir, writeSecureJson } from "../config/paths.js";
+
+export const LOCAL_STATE_DIR = ".c2c-local";
+
+function isInside(candidate: string, root: string): boolean {
+  const insensitive = process.platform === "win32" || process.platform === "darwin";
+  const normalize = (value: string): string => {
+    const resolved = path.resolve(value);
+    return insensitive ? resolved.toLowerCase() : resolved;
+  };
+  const child = normalize(candidate);
+  const parent = normalize(root);
+  return child === parent || child.startsWith(parent + path.sep);
+}
+
+/** Return a non-symlinked private state directory inside the selected workspace. */
+export function workspaceStateDir(workspaceRoot: string): string {
+  const root = fs.realpathSync.native(path.resolve(workspaceRoot));
+  const dir = path.join(root, LOCAL_STATE_DIR);
+  if (fs.existsSync(dir)) {
+    const stat = fs.lstatSync(dir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error(`${LOCAL_STATE_DIR} must be a regular directory inside the workspace`);
+    }
+  } else {
+    ensureDir(dir);
+  }
+  const real = fs.realpathSync.native(dir);
+  if (!isInside(real, root)) throw new Error(`${LOCAL_STATE_DIR} resolves outside the workspace`);
+  const ignoreFile = path.join(real, ".gitignore");
+  if (!fs.existsSync(ignoreFile)) fs.writeFileSync(ignoreFile, "*\n", { mode: 0o600 });
+  return real;
+}
+
+export function workspaceStateFile(workspaceRoot: string, name: string): string {
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(name)) throw new Error("Invalid workspace state filename");
+  return path.join(workspaceStateDir(workspaceRoot), name);
+}
+
+export function writeWorkspaceStateJson(workspaceRoot: string, name: string, data: unknown): string {
+  const file = workspaceStateFile(workspaceRoot, name);
+  writeSecureJson(file, data);
+  return file;
+}
+
+export function removeWorkspaceStateFile(workspaceRoot: string, name: string): void {
+  try {
+    fs.rmSync(workspaceStateFile(workspaceRoot, name), { force: true });
+  } catch {
+    // best effort cleanup of one exact private state file
+  }
+}
+
+export function writeWorkspaceStateText(workspaceRoot: string, name: string, value: string): string {
+  const file = workspaceStateFile(workspaceRoot, name);
+  fs.writeFileSync(file, value, { encoding: "utf8", mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best effort on filesystems without chmod semantics
+  }
+  return file;
+}
+
+export function acquireWorkspaceBridgeLock(workspaceRoot: string, instanceId: string): () => void {
+  const file = workspaceStateFile(workspaceRoot, "bridge.lock");
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = fs.openSync(file, "wx", 0o600);
+      fs.writeFileSync(fd, JSON.stringify({
+        pid: process.pid,
+        instanceId,
+        createdAt: new Date().toISOString(),
+      }));
+      fs.closeSync(fd);
+      return () => {
+        try {
+        const current = JSON.parse(fs.readFileSync(file, "utf8")) as { pid?: number; instanceId?: string };
+        if (current.pid === process.pid && current.instanceId === instanceId) fs.rmSync(file, { force: true });
+        } catch {
+          // best effort cleanup of this process's exact lock file
+        }
+      };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw error;
+      let liveDuringStartup = false;
+      try {
+        const current = JSON.parse(fs.readFileSync(file, "utf8")) as { pid?: number; createdAt?: string };
+        if (typeof current.pid === "number") {
+          process.kill(current.pid, 0);
+          const age = Date.now() - Date.parse(current.createdAt ?? "");
+          liveDuringStartup = Number.isFinite(age) && age >= 0 && age < 30_000;
+        }
+      } catch {
+        liveDuringStartup = false;
+      }
+      if (liveDuringStartup) throw new Error("A C2C bridge is already starting for this workspace");
+      fs.rmSync(file, { force: true });
+    }
+  }
+  throw new Error("Unable to acquire the workspace bridge lock");
+}

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -1,9 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import readline from "node:readline";
+import { StringDecoder } from "node:string_decoder";
 import { IgnoreRules } from "./ignore.js";
-import { readJsonIfExists } from "../config/paths.js";
 
 export type WorkspaceErrorCode =
   | "INVALID_PATH"
@@ -85,8 +84,11 @@ export class Workspace {
     this.root = real;
     this.id = createHash("sha256").update(normCase(real)).digest("hex").slice(0, 12);
     this.ignoreRules = new IgnoreRules(real);
-    this.projectConfig = readJsonIfExists<ProjectConfig>(path.join(real, ".c2c.json")) ?? {};
-    this.name = this.projectConfig.name ?? path.basename(real);
+    this.projectConfig = this.readWorkspaceJson<ProjectConfig>(".c2c.json", 64 * 1024) ?? {};
+    const configuredName = typeof this.projectConfig.name === "string"
+      ? this.projectConfig.name.replace(/[\u0000-\u001f\u007f]/g, " ").trim().slice(0, 200)
+      : "";
+    this.name = configuredName || path.basename(real);
   }
 
   private contains(candidate: string): boolean {
@@ -112,6 +114,26 @@ export class Workspace {
         suffix.unshift(path.basename(current));
         current = parent;
       }
+    }
+  }
+
+  private readWorkspaceJson<T>(relativePath: string, maxBytes: number): T | null {
+    try {
+      const { abs } = this.resolve(relativePath);
+      const stat = fs.statSync(abs);
+      if (!stat.isFile() || stat.size > maxBytes) return null;
+      return JSON.parse(fs.readFileSync(abs, "utf8")) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  private hasRegularWorkspaceFile(relativePath: string): boolean {
+    try {
+      const { abs } = this.resolve(relativePath);
+      return fs.statSync(abs).isFile();
+    } catch {
+      return false;
     }
   }
 
@@ -197,22 +219,80 @@ export class Workspace {
     let byteTruncated = false;
     let actualEnd = startLine - 1;
 
-    const stream = fs.createReadStream(abs, { encoding: "utf8" });
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    for await (const line of rl) {
-      totalLines++;
-      if (totalLines >= startLine && totalLines <= endLimit && !byteTruncated) {
-        const cost = Buffer.byteLength(line, "utf8") + 1;
-        if (collectedBytes + cost > maxBytes && lines.length > 0) {
+    const stream = fs.createReadStream(abs);
+    const decoder = new StringDecoder("utf8");
+    let lineNumber = 1;
+    let currentLine = "";
+    let selectedLineStarted = false;
+    let sawData = false;
+    let endedWithNewline = false;
+
+    const selected = (): boolean => lineNumber >= startLine && lineNumber <= endLimit;
+    const beginSelectedLine = (): void => {
+      if (!selected() || selectedLineStarted || byteTruncated) return;
+      selectedLineStarted = true;
+      if (lines.length > 0) {
+        if (collectedBytes >= maxBytes) {
           byteTruncated = true;
-        } else {
-          lines.push(line);
-          collectedBytes += cost;
-          actualEnd = totalLines;
+          return;
+        }
+        collectedBytes++;
+      }
+    };
+    const appendSelected = (text: string): void => {
+      if (!selected() || byteTruncated) return;
+      beginSelectedLine();
+      if (byteTruncated || text.length === 0) return;
+      const remaining = maxBytes - collectedBytes;
+      const encoded = Buffer.from(text, "utf8");
+      if (encoded.length <= remaining) {
+        currentLine += text;
+        collectedBytes += encoded.length;
+        return;
+      }
+      let clipped = encoded.subarray(0, Math.max(0, remaining)).toString("utf8");
+      if (clipped.endsWith("\uFFFD")) clipped = clipped.slice(0, -1);
+      currentLine += clipped;
+      collectedBytes += Buffer.byteLength(clipped, "utf8");
+      byteTruncated = true;
+    };
+    const finishLine = (): void => {
+      if (selected()) {
+        beginSelectedLine();
+        if (selectedLineStarted) {
+          lines.push(currentLine);
+          actualEnd = lineNumber;
         }
       }
-    }
-    rl.close();
+      totalLines = lineNumber;
+      lineNumber++;
+      currentLine = "";
+      selectedLineStarted = false;
+    };
+    const consume = (text: string): void => {
+      if (text.length === 0) return;
+      sawData = true;
+      let offset = 0;
+      for (;;) {
+        const newline = text.indexOf("\n", offset);
+        if (newline === -1) {
+          appendSelected(text.slice(offset));
+          endedWithNewline = false;
+          break;
+        }
+        let segment = text.slice(offset, newline);
+        if (segment.endsWith("\r")) segment = segment.slice(0, -1);
+        appendSelected(segment);
+        finishLine();
+        endedWithNewline = true;
+        offset = newline + 1;
+        if (offset === text.length) break;
+      }
+    };
+
+    for await (const chunk of stream) consume(decoder.write(chunk as Buffer));
+    consume(decoder.end());
+    if (sawData && !endedWithNewline) finishLine();
 
     const remaining = Math.max(0, totalLines - actualEnd);
     return {
@@ -221,7 +301,7 @@ export class Workspace {
       totalLines,
       startLine: Math.min(startLine, Math.max(totalLines, 1)),
       endLine: actualEnd,
-      truncated: remaining > 0,
+      truncated: byteTruncated || remaining > 0,
       remainingLines: remaining,
       nextStartLine: remaining > 0 ? actualEnd + 1 : null,
       content: lines.join("\n"),
@@ -298,7 +378,7 @@ export class Workspace {
     packageManager: string | null;
     scripts: Record<string, string>;
   } {
-    const has = (f: string): boolean => fs.existsSync(path.join(this.root, f));
+    const has = (f: string): boolean => this.hasRegularWorkspaceFile(f);
     const languages = new Set<string>();
     const frameworks = new Set<string>();
     let projectType = "unknown";
@@ -308,11 +388,11 @@ export class Workspace {
     if (has("package.json")) {
       projectType = "node";
       languages.add("JavaScript");
-      const pkg = readJsonIfExists<{
+      const pkg = this.readWorkspaceJson<{
         scripts?: Record<string, string>;
         dependencies?: Record<string, string>;
         devDependencies?: Record<string, string>;
-      }>(path.join(this.root, "package.json"));
+      }>("package.json", 1024 * 1024);
       scripts = pkg?.scripts ?? {};
       const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}) };
       const known: Record<string, string> = {

--- a/src/workspace/search.ts
+++ b/src/workspace/search.ts
@@ -2,7 +2,9 @@ import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
+import { Worker } from "node:worker_threads";
 import { Workspace } from "./manager.js";
+import { findTrustedExecutable } from "../process/executable.js";
 
 export interface SearchOptions {
   query: string;
@@ -26,7 +28,6 @@ export interface SearchResult {
 }
 
 const RG_CANDIDATES = [
-  "rg",
   "/opt/homebrew/bin/rg",
   "/usr/local/bin/rg",
   "/usr/bin/rg",
@@ -34,33 +35,72 @@ const RG_CANDIDATES = [
   "/Applications/Visual Studio Code.app/Contents/Resources/app/node_modules/@vscode/ripgrep/bin/rg",
 ];
 
-let cachedRg: string | null | undefined;
+const cachedRg = new Map<string, string | null>();
 
-export function findRipgrep(): string | null {
+export function findRipgrep(workspaceRoot?: string): string | null {
   if (process.env.C2C_DISABLE_RG === "1") return null;
-  if (cachedRg !== undefined) return cachedRg;
-  if (process.env.C2C_RG_PATH) {
-    cachedRg = process.env.C2C_RG_PATH;
-    return cachedRg;
-  }
-  for (const candidate of RG_CANDIDATES) {
+  const cacheKey = workspaceRoot ? path.resolve(workspaceRoot) : path.resolve(process.cwd());
+  if (cachedRg.has(cacheKey)) return cachedRg.get(cacheKey) ?? null;
+  const candidate = findTrustedExecutable("rg", {
+    override: process.env.C2C_RG_PATH,
+    additionalCandidates: RG_CANDIDATES,
+    forbiddenRoots: workspaceRoot ? [workspaceRoot] : [process.cwd()],
+  });
+  if (candidate) {
     try {
       const result = spawnSync(candidate, ["--version"], { stdio: "ignore", timeout: 3000 });
       if (result.status === 0) {
-        cachedRg = candidate;
+        cachedRg.set(cacheKey, candidate);
         return candidate;
       }
     } catch {
-      // try next candidate
+      // use the bounded Node fallback
     }
   }
-  cachedRg = null;
+  cachedRg.set(cacheKey, null);
   return null;
 }
 
 /** For tests. */
 export function resetRipgrepCache(): void {
-  cachedRg = undefined;
+  cachedRg.clear();
+}
+
+const REGEX_WORKER_SOURCE = `
+  const { parentPort, workerData } = require("node:worker_threads");
+  try {
+    const expression = new RegExp(workerData.pattern, "i");
+    const hits = [];
+    for (let index = 0; index < workerData.lines.length; index++) {
+      if (expression.test(workerData.lines[index])) hits.push(index);
+    }
+    parentPort.postMessage({ hits });
+  } catch (error) {
+    parentPort.postMessage({ error: error instanceof Error ? error.message : "Invalid regular expression" });
+  }
+`;
+
+async function boundedRegexMatches(pattern: string, lines: string[]): Promise<number[] | null> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(REGEX_WORKER_SOURCE, {
+      eval: true,
+      workerData: { pattern, lines },
+    });
+    const timer = setTimeout(() => {
+      void worker.terminate();
+      resolve(null);
+    }, 500);
+    worker.once("message", (message: { hits?: number[]; error?: string }) => {
+      clearTimeout(timer);
+      void worker.terminate();
+      if (message.error) reject(new Error(message.error));
+      else resolve(message.hits ?? []);
+    });
+    worker.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
 }
 
 async function searchWithRipgrep(
@@ -117,7 +157,6 @@ async function searchWithNode(
   opts: SearchOptions,
   limit: number
 ): Promise<SearchResult> {
-  const matcher = opts.regex ? new RegExp(opts.query, "i") : null;
   const needle = opts.query.toLowerCase();
   const globRegex = opts.glob ? globToRegex(opts.glob) : null;
   const matches: SearchMatch[] = [];
@@ -155,9 +194,18 @@ async function searchWithNode(
         }
         if (content.includes("\0")) continue;
         const lines = content.split("\n");
+        let regexHits: Set<number> | null = null;
+        if (opts.regex) {
+          const hitIndexes = await boundedRegexMatches(opts.query, lines);
+          if (hitIndexes === null) {
+            truncated = true;
+            return;
+          }
+          regexHits = new Set(hitIndexes);
+        }
         for (let i = 0; i < lines.length; i++) {
           const line = lines[i];
-          const hit = matcher ? matcher.test(line) : line.toLowerCase().includes(needle);
+          const hit = regexHits ? regexHits.has(i) : line.toLowerCase().includes(needle);
           if (hit) {
             matches.push({ path: childRel, line: i + 1, text: line.trimEnd().slice(0, 500) });
             if (matches.length >= limit) {
@@ -191,9 +239,13 @@ export async function searchWorkspace(ws: Workspace, opts: SearchOptions): Promi
   if (!opts.query || opts.query.length < 2) {
     return { matches: [], matchCount: 0, truncated: false, engine: "node" };
   }
+  if (opts.query.length > (opts.regex ? 256 : 4096)) {
+    throw new Error("Search query is too long");
+  }
+  if (opts.regex) new RegExp(opts.query, "i");
   const limit = Math.min(200, Math.max(1, Math.floor(opts.limit ?? 50)));
   const { abs } = ws.resolve(opts.path ?? ".");
-  const rg = findRipgrep();
+  const rg = findRipgrep(ws.root);
   if (rg) {
     try {
       return await searchWithRipgrep(ws, rg, abs, opts, limit);

--- a/tests/executable.test.ts
+++ b/tests/executable.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { findTrustedExecutable } from "../src/process/executable.js";
+import { cleanup, makeTmpDir } from "./helpers.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  while (dirs.length) cleanup(dirs.pop()!);
+});
+
+function fakeExecutable(dir: string, name: string): string {
+  const filename = process.platform === "win32" ? `${name}.exe` : name;
+  const file = path.join(dir, filename);
+  fs.writeFileSync(file, "test marker");
+  if (process.platform !== "win32") fs.chmodSync(file, 0o700);
+  return fs.realpathSync.native(file);
+}
+
+describe("trusted executable resolution", () => {
+  it("skips a workspace-local executable even when PATH lists it first", () => {
+    const workspace = makeTmpDir("exe-workspace");
+    const trustedDir = makeTmpDir("exe-trusted");
+    dirs.push(workspace, trustedDir);
+    fakeExecutable(workspace, "c2c-probe");
+    const trusted = fakeExecutable(trustedDir, "c2c-probe");
+
+    const found = findTrustedExecutable("c2c-probe", {
+      forbiddenRoots: [workspace],
+      pathValue: `${workspace}${path.delimiter}${trustedDir}`,
+    });
+    expect(found).toBe(trusted);
+  });
+
+  it("never returns a relative executable override", () => {
+    expect(findTrustedExecutable("c2c-probe", { override: ".\\c2c-probe.exe", pathValue: "" })).toBeNull();
+  });
+});

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import path from "node:path";
 import { gitDiff, gitInfo, gitStatus } from "../src/workspace/git.js";
+import { Workspace } from "../src/workspace/manager.js";
 import { makeTmpDir, cleanup, write, makeGitRepo, git } from "./helpers.js";
 
 let repo: string;
@@ -55,6 +56,17 @@ describe("gitStatus", () => {
 
     git(repo, "reset", "staged.txt");
     git(repo, "checkout", "--", "hello.txt");
+  });
+
+  it("does not reveal sensitive filenames in status output", () => {
+    write(repo, ".env", "SECRET=hidden\n");
+    write(repo, "nested/.npmrc", "TOKEN=hidden\n");
+    write(repo, "visible.txt", "safe\n");
+    const status = gitStatus(new Workspace(repo));
+    const serialized = JSON.stringify(status);
+    expect(serialized).not.toContain(".env");
+    expect(serialized).not.toContain(".npmrc");
+    expect(status.untracked).toContain("visible.txt");
   });
 });
 

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { Logger } from "../src/logger/index.js";
+import { makeTmpDir, cleanup } from "./helpers.js";
+
+describe("Logger", () => {
+  it("neutralizes forged line breaks while retaining one real log record", () => {
+    const dir = makeTmpDir("logger");
+    const file = path.join(dir, "security.log");
+    const logger = new Logger({ file });
+    logger.warn("failed input\n2099-01-01 ERROR [fake] forged\rentry");
+    const text = fs.readFileSync(file, "utf8");
+    expect(text.trimEnd().split("\n")).toHaveLength(1);
+    expect(text).toContain("\\n2099-01-01 ERROR");
+    expect(text).toContain("\\rentry");
+    cleanup(dir);
+  });
+});

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -27,11 +27,11 @@ afterAll(async () => {
   cleanup(root);
 });
 
-async function registerClient(): Promise<string> {
+async function registerClient(clientName = "ChatGPT-Test"): Promise<string> {
   const response = await fetch(`${base}/oauth/register`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ client_name: "ChatGPT-Test", redirect_uris: [REDIRECT_URI] }),
+    body: JSON.stringify({ client_name: clientName, redirect_uris: [REDIRECT_URI] }),
   });
   expect(response.status).toBe(201);
   const body = (await response.json()) as { client_id: string };
@@ -192,6 +192,44 @@ describe("authorization + token flow", () => {
     });
     expect(response.status).toBe(400);
   });
+
+  it("rejects arbitrary https redirect uris that are not ChatGPT connectors", async () => {
+    const response = await fetch(`${base}/oauth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ redirect_uris: ["https://evil.example.com/callback"] }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("escapes client-controlled text and displays the actual redirect origin", async () => {
+    const clientId = await registerClient('<img src=x onerror="globalThis.pwned=1">');
+    const { challenge } = pkceVerifierAndChallenge();
+    const authorizeUrl = new URL(`${base}/oauth/authorize`);
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+    const response = await fetch(authorizeUrl);
+    const html = await response.text();
+    expect(html).not.toContain('<img src=x onerror="globalThis.pwned=1">');
+    expect(html).toContain("&lt;img src=x onerror=&quot;globalThis.pwned=1&quot;&gt;");
+    expect(html).toContain("http://127.0.0.1:19999");
+    expect(response.headers.get("content-security-policy")).toContain("default-src 'none'");
+    expect(response.headers.get("content-security-policy")).toContain(
+      "form-action 'self' http://127.0.0.1:19999"
+    );
+  });
+
+  it("caps redirect URI registrations", async () => {
+    const response = await fetch(`${base}/oauth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ redirect_uris: Array.from({ length: 5 }, (_, i) => `http://127.0.0.1:${19000 + i}/cb`) }),
+    });
+    expect(response.status).toBe(400);
+  });
 });
 
 describe("token enforcement on /mcp", () => {
@@ -210,6 +248,15 @@ describe("token enforcement on /mcp", () => {
     const response = await mcpCall();
     expect(response.status).toBe(401);
     expect(response.headers.get("www-authenticate")).toContain("resource_metadata");
+  });
+
+  it("authenticates before parsing an invalid MCP body", async () => {
+    const response = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{" + "x".repeat(100_000),
+    });
+    expect(response.status).toBe(401);
   });
 
   it("401 with an invalid token", async () => {

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -67,6 +67,15 @@ describe("PairingManager", () => {
     expect(manager.verify(first.code).ok).toBe(false);
   });
 
+  it("allows request-scoped failures without invalidating the global pairing session", () => {
+    const manager = new PairingManager("ws1", { maxAttempts: 3, ipRateLimit: 100 });
+    const pairing = manager.create();
+    for (let i = 0; i < 10; i++) {
+      expect(manager.verify("AAAA-AAAA", `10.0.0.${i}`, { consumeFailure: false }).reason).toBe("invalid");
+    }
+    expect(manager.verify(pairing.code).ok).toBe(true);
+  });
+
   it("normalizes input", () => {
     expect(normalizePairingCode(" ab2-cd3 e ")).toBe("AB2CD3E");
     expect(formatPairingCode("ABCDEFGH")).toBe("ABCD-EFGH");

--- a/tests/port.test.ts
+++ b/tests/port.test.ts
@@ -30,12 +30,13 @@ describe("port collision handling", () => {
     expect(bridgeB.port).not.toBe(preferred);
     expect(bridgeB.port).toBeGreaterThan(0);
 
-    // health identifies each bridge's workspace, so callers can detect reuse
+    // health identifies each bridge instance without leaking a stable workspace fingerprint
     const healthA = await probeBridge(bridgeA.port);
     const healthB = await probeBridge(bridgeB.port);
-    expect(healthA?.workspaceId).toBe(bridgeA.workspace.id);
-    expect(healthB?.workspaceId).toBe(bridgeB.workspace.id);
-    expect(healthA?.workspaceId).not.toBe(healthB?.workspaceId);
+    expect(healthA?.instanceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(healthB?.instanceId).toMatch(/^[a-f0-9]{32}$/);
+    expect(healthA?.instanceId).not.toBe(healthB?.instanceId);
+    expect(healthA?.workspaceId).toBeUndefined();
 
     await bridgeA.close();
     await bridgeB.close();

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -90,4 +90,15 @@ describe.each(engines())("search engine: %s", (engine) => {
     expect(paths).toContain("src/auth.ts");
     expect(paths).not.toContain("README.md");
   });
+
+  if (engine === "node") {
+    it("terminates a catastrophic regular expression", async () => {
+      configure();
+      write(root, "regex-dos.txt", "a".repeat(200_000) + "!\n");
+      const started = Date.now();
+      const result = await searchWorkspace(ws, { query: "^(a+)+$", regex: true });
+      expect(Date.now() - started).toBeLessThan(3000);
+      expect(result.truncated).toBe(true);
+    });
+  }
 });

--- a/tests/state-security.test.ts
+++ b/tests/state-security.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { startBridge } from "../src/bridge/server.js";
+import { readRuntimeState, runtimeFile } from "../src/bridge/runtime.js";
+import { AuthStore } from "../src/auth/store.js";
+import { Workspace } from "../src/workspace/manager.js";
+import { acquireWorkspaceBridgeLock, workspaceStateFile } from "../src/workspace/local-state.js";
+import { makeTmpDir, cleanup, makeGitRepo, git, isolateStateDir } from "./helpers.js";
+
+describe("workspace-isolated security state", () => {
+  it("keeps runtime credentials out of shared state and prevents duplicate bridges", async () => {
+    const sharedState = isolateStateDir();
+    const root = makeTmpDir("state-ws");
+    makeGitRepo(root);
+    const bridge = await startBridge({ workspaceRoot: root, port: 0 });
+    try {
+      const runtimePath = runtimeFile(bridge.workspace.root);
+      const runtimeText = fs.readFileSync(runtimePath, "utf8");
+      expect(runtimeText).not.toContain("c2c_admin_");
+      expect(readRuntimeState(bridge.workspace.root)?.adminToken).toBeUndefined();
+      expect(fs.readFileSync(workspaceStateFile(bridge.workspace.root, "admin-token"), "utf8")).toBe(bridge.adminToken);
+      expect(fs.existsSync(path.join(sharedState, "runtime", `${bridge.workspace.id}.json`))).toBe(false);
+      expect(() => bridge.workspace.resolve(".c2c-local/admin-token")).toThrow(/ACCESS_DENIED/);
+      expect(git(root, "status", "--porcelain")).toBe("");
+
+      await expect(startBridge({ workspaceRoot: root, port: 0 })).rejects.toThrow(/already active/);
+    } finally {
+      await bridge.close();
+      cleanup(root);
+    }
+  });
+
+  it("migrates the previous auth file into the selected workspace once", () => {
+    const sharedState = isolateStateDir();
+    const root = makeTmpDir("state-migrate");
+    const workspace = new Workspace(root);
+    const legacy = path.join(sharedState, "auth", `${workspace.id}.json`);
+    fs.mkdirSync(path.dirname(legacy), { recursive: true });
+    fs.writeFileSync(legacy, JSON.stringify({
+      clients: [{
+        clientId: "c2c_client_existing",
+        clientName: "ChatGPT",
+        redirectUris: ["https://chatgpt.com/connector/oauth/existing"],
+        createdAt: new Date().toISOString(),
+      }],
+      tokens: [],
+    }));
+
+    const store = new AuthStore(workspace.id, { workspaceRoot: workspace.root });
+    expect(store.getClient("c2c_client_existing")?.clientName).toBe("ChatGPT");
+    expect(fs.existsSync(workspaceStateFile(workspace.root, "auth.json"))).toBe(true);
+    expect(fs.existsSync(legacy)).toBe(false);
+    cleanup(root);
+  });
+
+  it("recovers an old lock even when its PID has been reused", () => {
+    const root = makeTmpDir("state-stale-lock");
+    const lockFile = workspaceStateFile(root, "bridge.lock");
+    fs.writeFileSync(lockFile, JSON.stringify({
+      pid: process.pid,
+      instanceId: "stale-instance",
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    }));
+    const release = acquireWorkspaceBridgeLock(root, "fresh-instance");
+    const current = JSON.parse(fs.readFileSync(lockFile, "utf8")) as { instanceId: string };
+    expect(current.instanceId).toBe("fresh-instance");
+    release();
+    expect(fs.existsSync(lockFile)).toBe(false);
+    cleanup(root);
+  });
+});

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -163,6 +163,14 @@ describe("read_file pagination", () => {
   it("reports FILE_NOT_FOUND for missing files", async () => {
     await expect(ws.readFile("nope.txt")).rejects.toMatchObject({ code: "FILE_NOT_FOUND" });
   });
+
+  it("bounds a single very long line without materializing it in the response", async () => {
+    write(root, "one-long-line.txt", "x".repeat(4 * 1024 * 1024));
+    const result = await ws.readFile("one-long-line.txt", { maxBytes: 4096 });
+    expect(Buffer.byteLength(result.content, "utf8")).toBeLessThanOrEqual(4096);
+    expect(result.totalLines).toBe(1);
+    expect(result.truncated).toBe(true);
+  });
 });
 
 describe("workspace identity", () => {
@@ -180,5 +188,22 @@ describe("workspace identity", () => {
     expect(namedWs.name).toBe("Remi");
     expect(namedWs.projectConfig.maxIterations).toBe(12);
     cleanup(named);
+  });
+
+  it("does not inspect package.json through a symlink outside the workspace", () => {
+    if (!symlinksReady) return;
+    const project = makeTmpDir("project-link");
+    const external = makeTmpDir("project-external");
+    write(external, "package.json", JSON.stringify({ scripts: { leaked: "secret" }, dependencies: { react: "1" } }));
+    fs.symlinkSync(path.join(external, "package.json"), path.join(project, "package.json"));
+    const detected = new Workspace(project).detectProject();
+    expect(detected.scripts).toEqual({});
+    expect(detected.frameworks).not.toContain("React");
+    cleanup(project);
+    cleanup(external);
+  });
+
+  it("keeps C2C private state hidden from workspace reads", () => {
+    expect(() => ws.resolve(".c2c-local/runtime.json")).toThrow(/ACCESS_DENIED/);
   });
 });


### PR DESCRIPTION
## Summary

- isolate OAuth, runtime discovery, and admin credentials per workspace
- harden OAuth request validation, pairing attempts, executable resolution, and local bridge startup
- prevent sensitive-file leaks through Git diffs, workspace reads, searches, logs, and local state
- add regression tests and update security documentation

## Verification

- `corepack pnpm test` — 118 tests passed
- `corepack pnpm build` — passed
- `git diff --cached --check` — passed before commit
