### PR TITLE
fix(auth): harden OAuth pairing page rendering

### DIFF
--- a/src/auth/html.ts
+++ b/src/auth/html.ts
@@ -1,0 +1,21 @@
+import type { Response } from "express";
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function setAuthSecurityHeaders(res: Response): void {
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'"
+  );
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+}

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -4,6 +4,7 @@ import { AuthStore, SUPPORTED_SCOPES, base64UrlSha256, filterScopes, safeEqual }
 import { PairingManager } from "../pairing/manager.js";
 import type { Logger } from "../logger/index.js";
 import { PRODUCT_NAME } from "../version.js";
+import { escapeHtml, setAuthSecurityHeaders } from "./html.js";
 
 export interface OAuthDeps {
   store: AuthStore;
@@ -78,17 +79,20 @@ function pairingPage(opts: {
     offline_access: "Stay connected between sessions",
   };
   const scopeList = opts.scopes
-    .map((scope) => `<li>${scopeLabels[scope] ?? scope}</li>`)
+    .map((scope) => `<li>${escapeHtml(scopeLabels[scope] ?? scope)}</li>`)
     .join("");
   const errorHtml = opts.error
-    ? `<p class="error" role="alert">${opts.error}</p>`
+    ? `<p class="error" role="alert">${escapeHtml(opts.error)}</p>`
     : "";
+  const escapedProductName = escapeHtml(PRODUCT_NAME);
+  const escapedWorkspaceName = escapeHtml(opts.workspaceName);
+  const escapedRequestId = escapeHtml(opts.requestId);
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${PRODUCT_NAME}</title>
+<title>${escapedProductName}</title>
 <style>
   :root { color-scheme: light dark; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -114,11 +118,11 @@ function pairingPage(opts: {
 </head>
 <body>
 <div class="card">
-  <h1>${PRODUCT_NAME}</h1>
-  <p class="sub">ChatGPT is requesting access to workspace <strong>${opts.workspaceName}</strong> (read-only):</p>
+  <h1>${escapedProductName}</h1>
+  <p class="sub">ChatGPT is requesting access to workspace <strong>${escapedWorkspaceName}</strong> (read-only):</p>
   <ul>${scopeList}</ul>
   <form method="POST" action="authorize">
-    <input type="hidden" name="request_id" value="${opts.requestId}">
+    <input type="hidden" name="request_id" value="${escapedRequestId}">
     <input type="text" name="pairing_code" id="pairing_code" placeholder="XXXX-XXXX"
            autocomplete="one-time-code" autofocus maxlength="9" required>
     ${errorHtml}
@@ -192,11 +196,13 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     const query = req.query as Record<string, string | undefined>;
     const client = query.client_id ? deps.store.getClient(query.client_id) : undefined;
     if (!client) {
+      setAuthSecurityHeaders(res);
       res.status(400).send("Unknown client. Please reconnect from ChatGPT.");
       return;
     }
     const redirectUri = query.redirect_uri;
     if (!redirectUri || !client.redirectUris.includes(redirectUri)) {
+      setAuthSecurityHeaders(res);
       res.status(400).send("Invalid redirect_uri.");
       return;
     }
@@ -227,6 +233,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       expiresAt: Date.now() + 10 * 60_000,
     };
     pendingRequests.set(request.id, request);
+    setAuthSecurityHeaders(res);
     res
       .status(200)
       .type("html")
@@ -238,6 +245,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     const body = req.body as { request_id?: string; pairing_code?: string };
     const request = body.request_id ? pendingRequests.get(body.request_id) : undefined;
     if (!request) {
+      setAuthSecurityHeaders(res);
       res.status(400).send("This authorization request has expired. Please reconnect from ChatGPT.");
       return;
     }
@@ -251,6 +259,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
         no_active_session: "No active pairing session. Ask Codex to generate a pairing code.",
       };
       deps.logger.warn(`Pairing verification failed: ${verdict.reason}`);
+      setAuthSecurityHeaders(res);
       res
         .status(verdict.reason === "invalid" ? 401 : 410)
         .type("html")

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -152,6 +152,67 @@ describe("authorization + token flow", () => {
     expect(result.page).toContain("Incorrect pairing code");
   });
 
+  it("escapes the workspace name in the pairing page", async () => {
+    const xssWorkspaceRoot = makeTmpDir("oauth-html");
+    write(xssWorkspaceRoot, ".c2c.json", JSON.stringify({ name: "<script>alert('xss')</script>" }));
+    const xssBridge = await startBridge({
+      workspaceRoot: xssWorkspaceRoot,
+      port: 0,
+      persistRuntime: false,
+      authStoreFile: path.join(makeTmpDir("auth-html"), "store.json"),
+    });
+
+    try {
+      const xssBase = xssBridge.localBaseUrl();
+      const registration = await fetch(`${xssBase}/oauth/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ client_name: "HTML-Test", redirect_uris: [REDIRECT_URI] }),
+      });
+      expect(registration.status).toBe(201);
+      const client = (await registration.json()) as { client_id: string };
+      const { challenge } = pkceVerifierAndChallenge();
+
+      const authorizeUrl = new URL(`${xssBase}/oauth/authorize`);
+      authorizeUrl.searchParams.set("client_id", client.client_id);
+      authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+      authorizeUrl.searchParams.set("response_type", "code");
+      authorizeUrl.searchParams.set("code_challenge", challenge);
+      authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+      const response = await fetch(authorizeUrl, { redirect: "manual" });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+
+      expect(html).not.toContain("<script>alert('xss')</script>");
+      expect(html).toContain("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    } finally {
+      await xssBridge.close();
+      cleanup(xssWorkspaceRoot);
+    }
+  });
+
+  it("sets browser security headers on the pairing page", async () => {
+    const clientId = await registerClient();
+    const { challenge } = pkceVerifierAndChallenge();
+    const authorizeUrl = new URL(`${base}/oauth/authorize`);
+    authorizeUrl.searchParams.set("client_id", clientId);
+    authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+    authorizeUrl.searchParams.set("response_type", "code");
+    authorizeUrl.searchParams.set("code_challenge", challenge);
+    authorizeUrl.searchParams.set("code_challenge_method", "S256");
+
+    const response = await fetch(authorizeUrl, { redirect: "manual" });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'"
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+  });
+
   it("rejects PKCE verifier mismatch", async () => {
     const clientId = await registerClient();
     const { challenge } = pkceVerifierAndChallenge();


### PR DESCRIPTION
## Summary

This is a standalone follow-up to #10 and #23 focused only on the OAuth pairing page.

- Escape dynamic values rendered into the pairing HTML, including the workspace name, request ID, scope labels, error text, and product name.
- Add browser security headers to OAuth HTML responses: CSP, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, and Cache-Control.
- Add integration coverage for HTML escaping and response headers.

## Why

The workspace name comes from the connected workspace configuration or path and is rendered in the authorization page. Escaping keeps workspace-provided text as text. The page has no scripts and only needs inline styles, so the CSP is limited accordingly.

## Scope

This PR does not change scope validation, resource audience checks, tunnel providers, credential storage, pairing semantics, MCP permissions, or write access.

## Verification

- `corepack pnpm test` — 115 passed
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm audit --prod` — no known vulnerabilities
- `git diff --cached --check`