### PR TITLE
fix(auth): isolate pairing sessions per authorization request

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -263,12 +263,17 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       req.ip
     );
     if (!verdict.ok) {
+      const terminalFailure =
+        verdict.reason === "expired" ||
+        verdict.reason === "too_many_attempts" ||
+        verdict.reason === "no_active_session";
+      if (terminalFailure) pendingRequests.delete(request.id);
       const messages: Record<string, string> = {
         invalid: `Incorrect pairing code.${verdict.attemptsLeft !== undefined ? ` ${verdict.attemptsLeft} attempts left.` : ""}`,
-        expired: "This pairing code has expired. Ask Codex to generate a new one.",
-        too_many_attempts: "Too many incorrect attempts. Ask Codex to generate a new pairing code.",
+        expired: "This pairing request has expired. Generate a new pairing code and start a new connection from ChatGPT.",
+        too_many_attempts: "This pairing request is no longer valid. Generate a new pairing code and start a new connection from ChatGPT.",
         rate_limited: "Too many attempts. Please wait a minute and try again.",
-        no_active_session: "No active pairing session. Ask Codex to generate a pairing code.",
+        no_active_session: "No active pairing session. Generate a new pairing code and start a new connection from ChatGPT.",
       };
       deps.logger.warn(`Pairing verification failed: ${verdict.reason}`);
       setAuthSecurityHeaders(res);

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -16,7 +16,7 @@ export interface OAuthDeps {
 
 interface PendingAuthRequest {
   id: string;
-  pairingSessionId?: string;
+  pairingSessionId: string;
   clientId: string;
   redirectUri: string;
   scopes: string[];
@@ -223,9 +223,15 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       return;
     }
     const scopes = filterScopes(query.scope);
+    const pairingSessionId = deps.pairing.getActiveSessionId();
+    if (!pairingSessionId) {
+      setAuthSecurityHeaders(res);
+      res.status(400).send("No active pairing session. Ask Codex to generate a pairing code, then reconnect from ChatGPT.");
+      return;
+    }
     const request: PendingAuthRequest = {
       id: randomBytes(16).toString("hex"),
-      pairingSessionId: deps.pairing.getActiveSessionId(),
+      pairingSessionId,
       clientId: client.clientId,
       redirectUri,
       scopes,
@@ -251,9 +257,11 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       res.status(400).send("This authorization request has expired. Please reconnect from ChatGPT.");
       return;
     }
-    const verdict: PairingVerifyResult = request.pairingSessionId
-      ? deps.pairing.verifyForSession(request.pairingSessionId, body.pairing_code ?? "", req.ip)
-      : { ok: false, reason: "no_active_session" };
+    const verdict: PairingVerifyResult = deps.pairing.verifyForSession(
+      request.pairingSessionId,
+      body.pairing_code ?? "",
+      req.ip
+    );
     if (!verdict.ok) {
       const messages: Record<string, string> = {
         invalid: `Incorrect pairing code.${verdict.attemptsLeft !== undefined ? ` ${verdict.attemptsLeft} attempts left.` : ""}`,

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response, urlencoded, json } from "express";
 import { randomBytes } from "node:crypto";
 import { AuthStore, SUPPORTED_SCOPES, base64UrlSha256, filterScopes, safeEqual } from "./store.js";
-import { PairingManager } from "../pairing/manager.js";
+import { PairingManager, type PairingVerifyResult } from "../pairing/manager.js";
 import type { Logger } from "../logger/index.js";
 import { PRODUCT_NAME } from "../version.js";
 import { escapeHtml, setAuthSecurityHeaders } from "./html.js";
@@ -16,6 +16,7 @@ export interface OAuthDeps {
 
 interface PendingAuthRequest {
   id: string;
+  pairingSessionId?: string;
   clientId: string;
   redirectUri: string;
   scopes: string[];
@@ -224,6 +225,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     const scopes = filterScopes(query.scope);
     const request: PendingAuthRequest = {
       id: randomBytes(16).toString("hex"),
+      pairingSessionId: deps.pairing.getActiveSessionId(),
       clientId: client.clientId,
       redirectUri,
       scopes,
@@ -249,7 +251,9 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       res.status(400).send("This authorization request has expired. Please reconnect from ChatGPT.");
       return;
     }
-    const verdict = deps.pairing.verify(body.pairing_code ?? "", req.ip);
+    const verdict: PairingVerifyResult = request.pairingSessionId
+      ? deps.pairing.verifyForSession(request.pairingSessionId, body.pairing_code ?? "", req.ip)
+      : { ok: false, reason: "no_active_session" };
     if (!verdict.ok) {
       const messages: Record<string, string> = {
         invalid: `Incorrect pairing code.${verdict.attemptsLeft !== undefined ? ` ${verdict.attemptsLeft} attempts left.` : ""}`,

--- a/src/pairing/manager.ts
+++ b/src/pairing/manager.ts
@@ -82,21 +82,28 @@ export class PairingManager {
     this.ipRateWindowMs = opts.ipRateWindowMs ?? 60_000;
   }
 
-  /** Create a new pairing session. Invalidates previous sessions (one active at a time). */
+  /** Create a new pairing session while preserving other unexpired sessions. */
   create(): { sessionId: string; code: string; expiresAt: number } {
-    this.sessions.clear();
+    this.pruneExpiredSessions();
     const raw = generateCode();
+    const createdAt = Date.now();
     const session: PairingSession = {
       id: randomBytes(16).toString("hex"),
       codeHash: hashCode(raw),
       workspaceId: this.workspaceId,
-      createdAt: Date.now(),
-      expiresAt: Date.now() + this.ttlMs,
+      createdAt,
+      expiresAt: createdAt + this.ttlMs,
       attemptsLeft: this.maxAttempts,
       used: false,
     };
     this.sessions.set(session.id, session);
     return { sessionId: session.id, code: formatPairingCode(raw), expiresAt: session.expiresAt };
+  }
+
+  private pruneExpiredSessions(now = Date.now()): void {
+    for (const [id, session] of this.sessions) {
+      if (now > session.expiresAt) this.sessions.delete(id);
+    }
   }
 
   private checkIpRate(ip: string | undefined): boolean {
@@ -115,45 +122,69 @@ export class PairingManager {
     if (!this.checkIpRate(ip)) {
       return { ok: false, reason: "rate_limited" };
     }
+    const sessionId = this.getLatestSessionId();
+    return sessionId ? this.verifySession(sessionId, codeInput) : { ok: false, reason: "no_active_session" };
+  }
+
+  private getLatestSessionId(): string | undefined {
+    const sessions = [...this.sessions.values()];
+    for (let index = sessions.length - 1; index >= 0; index--) {
+      if (!sessions[index].used) return sessions[index].id;
+    }
+    return undefined;
+  }
+
+  getActiveSessionId(): string | undefined {
+    const now = Date.now();
+    this.pruneExpiredSessions(now);
+    const sessions = [...this.sessions.values()];
+    for (let index = sessions.length - 1; index >= 0; index--) {
+      const session = sessions[index];
+      if (!session.used && session.attemptsLeft > 0 && now <= session.expiresAt) return session.id;
+    }
+    return undefined;
+  }
+
+  verifyForSession(sessionId: string, codeInput: string, ip?: string): PairingVerifyResult {
+    if (!this.checkIpRate(ip)) {
+      return { ok: false, reason: "rate_limited" };
+    }
+    return this.verifySession(sessionId, codeInput);
+  }
+
+  private verifySession(sessionId: string, codeInput: string): PairingVerifyResult {
+    const session = this.sessions.get(sessionId);
+    if (!session || session.used) return { ok: false, reason: "no_active_session" };
+
+    const now = Date.now();
+    if (now > session.expiresAt) {
+      this.sessions.delete(session.id);
+      return { ok: false, reason: "expired" };
+    }
+    if (session.attemptsLeft <= 0) {
+      this.sessions.delete(session.id);
+      return { ok: false, reason: "too_many_attempts" };
+    }
+
     const normalized = normalizePairingCode(codeInput);
     const inputHash = hashCode(normalized);
-    const now = Date.now();
-
-    const active = [...this.sessions.values()].filter((s) => !s.used);
-    if (active.length === 0) return { ok: false, reason: "no_active_session" };
-
-    for (const session of active) {
-      if (now > session.expiresAt) {
-        this.sessions.delete(session.id);
-        return { ok: false, reason: "expired" };
-      }
-      if (session.attemptsLeft <= 0) {
-        this.sessions.delete(session.id);
-        return { ok: false, reason: "too_many_attempts" };
-      }
-      const match = timingSafeEqual(inputHash, session.codeHash);
-      if (match) {
-        // one-time use: destroy immediately
-        session.used = true;
-        this.sessions.delete(session.id);
-        return { ok: true, sessionId: session.id };
-      }
-      session.attemptsLeft--;
-      if (session.attemptsLeft <= 0) {
-        this.sessions.delete(session.id);
-        return { ok: false, reason: "too_many_attempts" };
-      }
-      return { ok: false, reason: "invalid", attemptsLeft: session.attemptsLeft };
+    if (timingSafeEqual(inputHash, session.codeHash)) {
+      // one-time use: destroy immediately
+      session.used = true;
+      this.sessions.delete(session.id);
+      return { ok: true, sessionId: session.id };
     }
-    return { ok: false, reason: "no_active_session" };
+
+    session.attemptsLeft--;
+    if (session.attemptsLeft <= 0) {
+      this.sessions.delete(session.id);
+      return { ok: false, reason: "too_many_attempts" };
+    }
+    return { ok: false, reason: "invalid", attemptsLeft: session.attemptsLeft };
   }
 
   hasActiveSession(): boolean {
-    const now = Date.now();
-    for (const session of this.sessions.values()) {
-      if (!session.used && now <= session.expiresAt) return true;
-    }
-    return false;
+    return this.getActiveSessionId() !== undefined;
   }
 
   invalidateAll(): void {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -223,6 +223,22 @@ describe("authorization + token flow", () => {
       );
       expect(staleRequest.status).toBe(400);
       expect(staleRequest.page).toContain("authorization request has expired");
+
+      const freshAuthorization = await beginAuthorization(
+        clientId,
+        challenge,
+        "fresh-request",
+        expiryBase
+      );
+      expect(freshAuthorization.status).toBe(200);
+      expect(freshAuthorization.requestId).toBeTruthy();
+      const freshResult = await submitAuthorization(
+        freshAuthorization.requestId!,
+        freshPairing.code,
+        expiryBase
+      );
+      expect(freshResult.status).toBe(302);
+      expect(freshResult.code).toBeTruthy();
     } finally {
       await expiryBridge.close();
       cleanup(expiryRoot);

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -27,8 +27,8 @@ afterAll(async () => {
   cleanup(root);
 });
 
-async function registerClient(): Promise<string> {
-  const response = await fetch(`${base}/oauth/register`, {
+async function registerClient(baseUrl = base): Promise<string> {
+  const response = await fetch(`${baseUrl}/oauth/register`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ client_name: "ChatGPT-Test", redirect_uris: [REDIRECT_URI] }),
@@ -54,9 +54,10 @@ async function authorizeWithPairing(
 async function beginAuthorization(
   clientId: string,
   challenge: string,
-  state = "st-123"
+  state = "st-123",
+  baseUrl = base
 ): Promise<{ requestId: string | null; page: string; status: number }> {
-  const authorizeUrl = new URL(`${base}/oauth/authorize`);
+  const authorizeUrl = new URL(`${baseUrl}/oauth/authorize`);
   authorizeUrl.searchParams.set("client_id", clientId);
   authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
   authorizeUrl.searchParams.set("response_type", "code");
@@ -73,9 +74,10 @@ async function beginAuthorization(
 
 async function submitAuthorization(
   requestId: string,
-  pairingCode: string
+  pairingCode: string,
+  baseUrl = base
 ): Promise<{ code: string | null; location: string | null; page?: string; status?: number }> {
-  const postResponse = await fetch(`${base}/oauth/authorize`, {
+  const postResponse = await fetch(`${baseUrl}/oauth/authorize`, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({ request_id: requestId, pairing_code: pairingCode }),
@@ -187,6 +189,44 @@ describe("authorization + token flow", () => {
     expect(freshAuthorization.requestId).toBeTruthy();
     const freshResult = await submitAuthorization(freshAuthorization.requestId!, pairing.code);
     expect(freshResult.code).toBeTruthy();
+  });
+
+  it("expires an authorization request when its pairing session expires", async () => {
+    const expiryRoot = makeTmpDir("oauth-expiry");
+    write(expiryRoot, "hello.txt", "hello expiry\n");
+    const expiryBridge = await startBridge({
+      workspaceRoot: expiryRoot,
+      port: 0,
+      persistRuntime: false,
+      pairingTtlMs: 10,
+      authStoreFile: path.join(makeTmpDir("auth-expiry"), "store.json"),
+    });
+
+    try {
+      const expiryBase = expiryBridge.localBaseUrl();
+      const clientId = await registerClient(expiryBase);
+      const { challenge } = pkceVerifierAndChallenge();
+      const pairing = expiryBridge.pairing.create();
+      const authorization = await beginAuthorization(clientId, challenge, "expired-request", expiryBase);
+      expect(authorization.requestId).toBeTruthy();
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const expired = await submitAuthorization(authorization.requestId!, pairing.code, expiryBase);
+      expect(expired.status).toBe(410);
+      expect(expired.page).toContain("start a new connection");
+
+      const freshPairing = expiryBridge.pairing.create();
+      const staleRequest = await submitAuthorization(
+        authorization.requestId!,
+        freshPairing.code,
+        expiryBase
+      );
+      expect(staleRequest.status).toBe(400);
+      expect(staleRequest.page).toContain("authorization request has expired");
+    } finally {
+      await expiryBridge.close();
+      cleanup(expiryRoot);
+    }
   });
 
   it("binds concurrent authorization requests to their pairing sessions", async () => {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -169,6 +169,26 @@ describe("authorization + token flow", () => {
     expect(result.page).toContain("Incorrect pairing code");
   });
 
+  it("does not create an authorization request without an active pairing session", async () => {
+    const clientId = await registerClient();
+    const { challenge } = pkceVerifierAndChallenge();
+    bridge.pairing.invalidateAll();
+
+    const authorization = await beginAuthorization(clientId, challenge);
+    expect(authorization.status).toBe(400);
+    expect(authorization.requestId).toBeNull();
+    expect(authorization.page).toContain("No active pairing session");
+
+    const pairing = bridge.pairing.create();
+    expect(authorization.requestId).toBeNull();
+
+    const freshAuthorization = await beginAuthorization(clientId, challenge);
+    expect(freshAuthorization.status).toBe(200);
+    expect(freshAuthorization.requestId).toBeTruthy();
+    const freshResult = await submitAuthorization(freshAuthorization.requestId!, pairing.code);
+    expect(freshResult.code).toBeTruthy();
+  });
+
   it("binds concurrent authorization requests to their pairing sessions", async () => {
     const clientId = await registerClient();
     const firstPkce = pkceVerifierAndChallenge();
@@ -211,6 +231,7 @@ describe("authorization + token flow", () => {
       expect(registration.status).toBe(201);
       const client = (await registration.json()) as { client_id: string };
       const { challenge } = pkceVerifierAndChallenge();
+      xssBridge.pairing.create();
 
       const authorizeUrl = new URL(`${xssBase}/oauth/authorize`);
       authorizeUrl.searchParams.set("client_id", client.client_id);
@@ -234,6 +255,7 @@ describe("authorization + token flow", () => {
   it("sets browser security headers on the pairing page", async () => {
     const clientId = await registerClient();
     const { challenge } = pkceVerifierAndChallenge();
+    bridge.pairing.create();
     const authorizeUrl = new URL(`${base}/oauth/authorize`);
     authorizeUrl.searchParams.set("client_id", clientId);
     authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -44,6 +44,18 @@ async function authorizeWithPairing(
   pairingCode: string,
   state = "st-123"
 ): Promise<{ code: string | null; location: string | null; page?: string; status?: number }> {
+  const authorization = await beginAuthorization(clientId, challenge, state);
+  if (!authorization.requestId) {
+    return { code: null, location: null, page: authorization.page, status: authorization.status };
+  }
+  return submitAuthorization(authorization.requestId, pairingCode);
+}
+
+async function beginAuthorization(
+  clientId: string,
+  challenge: string,
+  state = "st-123"
+): Promise<{ requestId: string | null; page: string; status: number }> {
   const authorizeUrl = new URL(`${base}/oauth/authorize`);
   authorizeUrl.searchParams.set("client_id", clientId);
   authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
@@ -56,8 +68,13 @@ async function authorizeWithPairing(
   const pageResponse = await fetch(authorizeUrl, { redirect: "manual" });
   const html = await pageResponse.text();
   const requestId = html.match(/name="request_id" value="([a-f0-9]+)"/)?.[1];
-  if (!requestId) return { code: null, location: null, page: html, status: pageResponse.status };
+  return { requestId: requestId ?? null, page: html, status: pageResponse.status };
+}
 
+async function submitAuthorization(
+  requestId: string,
+  pairingCode: string
+): Promise<{ code: string | null; location: string | null; page?: string; status?: number }> {
   const postResponse = await fetch(`${base}/oauth/authorize`, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -150,6 +167,28 @@ describe("authorization + token flow", () => {
     expect(result.code).toBeNull();
     expect(result.status).toBe(401);
     expect(result.page).toContain("Incorrect pairing code");
+  });
+
+  it("binds concurrent authorization requests to their pairing sessions", async () => {
+    const clientId = await registerClient();
+    const firstPkce = pkceVerifierAndChallenge();
+    const secondPkce = pkceVerifierAndChallenge();
+    const firstPairing = bridge.pairing.create();
+    const firstAuthorization = await beginAuthorization(clientId, firstPkce.challenge, "first-request");
+    const secondPairing = bridge.pairing.create();
+    const secondAuthorization = await beginAuthorization(clientId, secondPkce.challenge, "second-request");
+
+    expect(firstAuthorization.requestId).toBeTruthy();
+    expect(secondAuthorization.requestId).toBeTruthy();
+
+    const crossRequest = await submitAuthorization(secondAuthorization.requestId!, firstPairing.code);
+    expect(crossRequest.status).toBe(401);
+    expect(crossRequest.page).toContain("Incorrect pairing code");
+
+    const firstResult = await submitAuthorization(firstAuthorization.requestId!, firstPairing.code);
+    expect(firstResult.code).toBeTruthy();
+    const secondResult = await submitAuthorization(secondAuthorization.requestId!, secondPairing.code);
+    expect(secondResult.code).toBeTruthy();
   });
 
   it("escapes the workspace name in the pairing page", async () => {

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -60,11 +60,40 @@ describe("PairingManager", () => {
     expect(manager.verify("AAAA-AAAA", "5.6.7.8").reason).not.toBe("rate_limited");
   });
 
-  it("invalidates previous sessions when creating a new one", () => {
+  it("keeps previous sessions active and exposes the newest active session", () => {
     const manager = new PairingManager("ws1");
     const first = manager.create();
-    manager.create();
-    expect(manager.verify(first.code).ok).toBe(false);
+    const second = manager.create();
+
+    expect(manager.getActiveSessionId()).toBe(second.sessionId);
+    expect(manager.verifyForSession(first.sessionId, first.code)).toMatchObject({
+      ok: true,
+      sessionId: first.sessionId,
+    });
+    expect(manager.verifyForSession(second.sessionId, second.code)).toMatchObject({
+      ok: true,
+      sessionId: second.sessionId,
+    });
+  });
+
+  it("limits a code mismatch to the requested session", () => {
+    const manager = new PairingManager("ws1");
+    const first = manager.create();
+    const second = manager.create();
+
+    expect(manager.verifyForSession(second.sessionId, first.code)).toMatchObject({
+      ok: false,
+      reason: "invalid",
+      attemptsLeft: 4,
+    });
+    expect(manager.verifyForSession(first.sessionId, first.code)).toMatchObject({
+      ok: true,
+      sessionId: first.sessionId,
+    });
+    expect(manager.verifyForSession(second.sessionId, second.code)).toMatchObject({
+      ok: true,
+      sessionId: second.sessionId,
+    });
   });
 
   it("normalizes input", () => {


### PR DESCRIPTION
## Summary

- Preserve multiple short-lived pairing sessions instead of invalidating earlier sessions when a new code is generated.
- Bind each OAuth authorization request to the pairing session that was active when the request started.
- Reject authorization initiation when there is no pairing session to bind, avoiding permanently unusable pending requests.
- Expire pending OAuth requests when their bound pairing session reaches a terminal failure.

## Observed Problem

In real use, reconnecting from an existing conversation was not reliable. ChatGPT repeatedly showed “We couldn't connect your account”. After a temporary public address changed, opening the old address could no longer reach the server. Re-authentication alone did not consistently restore the existing conversation, and starting a new conversation was the reliable recovery path.

These observations motivated the reproducible pairing/request race scenario below. This PR does not claim to solve all of those symptoms; the code change is intentionally limited to the server-side pairing/session invalidation and OAuth request-binding problem.

## Root Cause

`PairingManager.create()` cleared every existing pairing session. In addition, the OAuth POST handler verified a code through a global session lookup rather than the session associated with the authorization request. Overlapping reconnect attempts could therefore invalidate an earlier request or allow a code from one request's session to satisfy another request.

Pending requests also remained stored after their bound pairing session expired or became unusable. The old page then suggested generating a new code even though that request could never accept a replacement code.

## Changes

- Keep unexpired pairing sessions alive and prune only expired sessions when creating a new code.
- Add a server-side active-session lookup and session-specific verification while preserving the existing `verify(code, ip?)` API.
- Store a required `pairingSessionId` on each pending OAuth request.
- Verify OAuth submissions only against their stored pairing session.
- Reject `/oauth/authorize` GET requests when no pairing session exists, without creating an unbound pending request.
- Delete pending OAuth requests on terminal pairing failures (`expired`, `too_many_attempts`, or `no_active_session`) and instruct the user to start a new connection.
- Add pairing-manager and endpoint-level regression tests for overlapping sessions, cross-request submissions, failed-GET recovery, stale-request rejection, and fresh authorization recovery.

## Compatibility

- The browser form remains unchanged and exposes only the existing opaque `request_id` and pairing code.
- The existing five-minute TTL, attempt limit, per-IP rate limit, normalization, one-time use, and `invalidateAll()` behavior remain in place.
- Redirect handling, state, PKCE S256, scopes, authorization-code handling, refresh-token rotation, CSP/security headers, and credential storage are unchanged.
- Retryable invalid-code and rate-limit failures still keep the pending request available; only terminal pairing failures expire it.

## Tests

- `corepack pnpm test` — 129 tests passed
- `corepack pnpm typecheck` — passed
- `corepack pnpm build` — passed
- `corepack pnpm audit --prod` — no known vulnerabilities
- `git diff --check` — passed
- The OAuth integration tests exercise the bridge's authorization flow with two concurrent pairing sessions, verify cross-submission rejection and independent success, and verify that an expired request cannot reuse a later code while a fresh request succeeds.

## Limitations

- This does not fix temporary/public address changes or the availability of an old address.
- This does not fix ChatGPT-side account connection or OAuth/token-exchange failures.
- This does not claim to resolve every existing-conversation reconnect failure.

Relates to #5
