### PR TITLE
fix(git): hide sensitive paths from status

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -179,7 +179,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "git.read");
       if (denied) return denied;
       try {
-        return ok(gitStatus(workspace.root));
+        return ok(gitStatus(workspace));
       } catch (error) {
         return mapError(error);
       }

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -60,7 +60,14 @@ export interface GitStatusResult {
   conflicted: string[];
 }
 
-export function gitStatus(root: string): GitStatusResult {
+export function gitStatus(target: GitTarget): GitStatusResult {
+  const root = typeof target === "string" ? target : target.root;
+  const ignoreRules =
+    typeof target === "object" && target.ignoreRules
+      ? target.ignoreRules
+      : new IgnoreRules(root);
+  const isSafe = (filePath: string): boolean =>
+    !ignoreRules.isSensitive(filePath.replace(/\\/g, "/"));
   const empty: GitStatusResult = {
     isRepo: false,
     branch: null,
@@ -72,35 +79,44 @@ export function gitStatus(root: string): GitStatusResult {
     untracked: [],
     conflicted: [],
   };
-  const result = runGit(root, ["status", "--porcelain=v2", "--branch", "--", "."]);
+  const result = runGit(root, ["status", "--porcelain=v2", "-z", "--branch", "--", "."]);
   if (!result.ok) return empty;
   const out: GitStatusResult = { ...empty, isRepo: true };
-  for (const line of result.stdout.split("\n")) {
-    if (line.startsWith("# branch.head ")) {
-      out.branch = line.slice("# branch.head ".length).trim();
-    } else if (line.startsWith("# branch.upstream ")) {
-      out.upstream = line.slice("# branch.upstream ".length).trim();
-    } else if (line.startsWith("# branch.ab ")) {
-      const m = line.match(/\+(\d+) -(\d+)/);
+  const records = result.stdout.split("\0");
+  for (let index = 0; index < records.length; index++) {
+    const record = records[index];
+    if (record.startsWith("# branch.head ")) {
+      out.branch = record.slice("# branch.head ".length).trim();
+    } else if (record.startsWith("# branch.upstream ")) {
+      out.upstream = record.slice("# branch.upstream ".length).trim();
+    } else if (record.startsWith("# branch.ab ")) {
+      const m = record.match(/\+(\d+) -(\d+)/);
       if (m) {
         out.ahead = parseInt(m[1], 10);
         out.behind = parseInt(m[2], 10);
       }
-    } else if (line.startsWith("1 ") || line.startsWith("2 ")) {
-      const parts = line.split(" ");
-      const xy = parts[1];
-      const filePath = line.startsWith("2 ")
-        ? line.split("\t")[0]?.split(" ").slice(9).join(" ") + " -> " + (line.split("\t")[1] ?? "")
-        : parts.slice(8).join(" ");
-      const x = xy[0];
-      const y = xy[1];
-      if (x !== ".") out.staged.push({ path: filePath, change: x });
-      if (y !== ".") out.unstaged.push({ path: filePath, change: y });
-    } else if (line.startsWith("? ")) {
-      out.untracked.push(line.slice(2));
-    } else if (line.startsWith("u ")) {
-      const parts = line.split(" ");
-      out.conflicted.push(parts.slice(10).join(" "));
+    } else if (record.startsWith("1 ")) {
+      const match = /^1 ([^ ]{2}) (?:[^ ]+ ){6}([\s\S]*)$/.exec(record);
+      if (!match) continue;
+      const [, xy, filePath] = match;
+      if (!isSafe(filePath)) continue;
+      if (xy[0] !== ".") out.staged.push({ path: filePath, change: xy[0] });
+      if (xy[1] !== ".") out.unstaged.push({ path: filePath, change: xy[1] });
+    } else if (record.startsWith("2 ")) {
+      const match = /^2 ([^ ]{2}) (?:[^ ]+ ){7}([\s\S]*)$/.exec(record);
+      const oldPath = records[++index] ?? "";
+      if (!match) continue;
+      const [, xy, newPath] = match;
+      if (!isSafe(oldPath) || !isSafe(newPath)) continue;
+      const filePath = `${oldPath} -> ${newPath}`;
+      if (xy[0] !== ".") out.staged.push({ path: filePath, change: xy[0] });
+      if (xy[1] !== ".") out.unstaged.push({ path: filePath, change: xy[1] });
+    } else if (record.startsWith("? ")) {
+      const filePath = record.slice(2);
+      if (isSafe(filePath)) out.untracked.push(filePath);
+    } else if (record.startsWith("u ")) {
+      const match = /^u [^ ]{2} (?:[^ ]+ ){8}([\s\S]*)$/.exec(record);
+      if (match && isSafe(match[1])) out.conflicted.push(match[1]);
     }
   }
   return out;

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import path from "node:path";
 import { gitDiff, gitInfo, gitStatus } from "../src/workspace/git.js";
+import { Workspace } from "../src/workspace/manager.js";
 import { makeTmpDir, cleanup, write, makeGitRepo, git } from "./helpers.js";
 
 let repo: string;
@@ -55,6 +56,18 @@ describe("gitStatus", () => {
 
     git(repo, "reset", "staged.txt");
     git(repo, "checkout", "--", "hello.txt");
+  });
+
+  it("does not reveal sensitive filenames in status output", () => {
+    write(repo, ".env", "SECRET=hidden\n");
+    write(repo, "nested/.npmrc", "TOKEN=hidden\n");
+    write(repo, "visible.txt", "safe\n");
+
+    const status = gitStatus(new Workspace(repo));
+    const serialized = JSON.stringify(status);
+    expect(serialized).not.toContain(".env");
+    expect(serialized).not.toContain(".npmrc");
+    expect(status.untracked).toContain("visible.txt");
   });
 });
 


### PR DESCRIPTION
## Summary

- Filter `git_status` results through the workspace's existing sensitive-file rules.
- Parse NUL-delimited porcelain v2 output so paths, including renames, are handled without leaking sensitive names.
- Add a regression test that hides `.env` and `.npmrc` while preserving ordinary status entries.

## Context

This is an independent follow-up to #23, split out according to the maintainer's guidance.

## Scope

This PR is limited to `git_status` output. It does not change credential storage, OAuth behavior, or `git_diff` behavior.

## Verification

- Focused Git tests: 14 passed.
- Full test suite: 126 passed.
- TypeScript build passed.
