### PR TITLE
fix(auth): isolate pairing attempts per request

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -23,7 +23,10 @@ interface PendingAuthRequest {
   codeChallenge: string;
   resource?: string;
   expiresAt: number;
+  attemptsLeft: number;
 }
+
+const PAIRING_ATTEMPTS_PER_REQUEST = 5;
 
 function isAllowedRedirectUri(uri: string): boolean {
   let parsed: URL;
@@ -231,6 +234,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       codeChallenge: query.code_challenge,
       resource: query.resource,
       expiresAt: Date.now() + 10 * 60_000,
+      attemptsLeft: PAIRING_ATTEMPTS_PER_REQUEST,
     };
     pendingRequests.set(request.id, request);
     setAuthSecurityHeaders(res);
@@ -249,10 +253,29 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
       res.status(400).send("This authorization request has expired. Please reconnect from ChatGPT.");
       return;
     }
-    const verdict = deps.pairing.verify(body.pairing_code ?? "", req.ip);
+    const verdict = deps.pairing.verify(body.pairing_code ?? "", req.ip, { consumeFailure: false });
     if (!verdict.ok) {
+      if (verdict.reason === "invalid") {
+        request.attemptsLeft--;
+        if (request.attemptsLeft <= 0) {
+          pendingRequests.delete(request.id);
+          setAuthSecurityHeaders(res);
+          res
+            .status(410)
+            .type("html")
+            .send(
+              pairingPage({
+                requestId: request.id,
+                workspaceName: deps.workspaceName,
+                scopes: request.scopes,
+                error: "Too many incorrect attempts. Restart the connection from ChatGPT.",
+              })
+            );
+          return;
+        }
+      }
       const messages: Record<string, string> = {
-        invalid: `Incorrect pairing code.${verdict.attemptsLeft !== undefined ? ` ${verdict.attemptsLeft} attempts left.` : ""}`,
+        invalid: `Incorrect pairing code. ${request.attemptsLeft} attempts left.`,
         expired: "This pairing code has expired. Ask Codex to generate a new one.",
         too_many_attempts: "Too many incorrect attempts. Ask Codex to generate a new pairing code.",
         rate_limited: "Too many attempts. Please wait a minute and try again.",

--- a/src/pairing/manager.ts
+++ b/src/pairing/manager.ts
@@ -111,7 +111,11 @@ export class PairingManager {
     return entry.count <= this.ipRateLimit;
   }
 
-  verify(codeInput: string, ip?: string): PairingVerifyResult {
+  verify(
+    codeInput: string,
+    ip?: string,
+    opts: { consumeFailure?: boolean } = {}
+  ): PairingVerifyResult {
     if (!this.checkIpRate(ip)) {
       return { ok: false, reason: "rate_limited" };
     }
@@ -137,6 +141,9 @@ export class PairingManager {
         session.used = true;
         this.sessions.delete(session.id);
         return { ok: true, sessionId: session.id };
+      }
+      if (opts.consumeFailure === false) {
+        return { ok: false, reason: "invalid" };
       }
       session.attemptsLeft--;
       if (session.attemptsLeft <= 0) {

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -152,6 +152,64 @@ describe("authorization + token flow", () => {
     expect(result.page).toContain("Incorrect pairing code");
   });
 
+  it("isolates failed pairing attempts to one authorization request", async () => {
+    const isolatedRoot = makeTmpDir("oauth-attempts");
+    const isolatedAuth = makeTmpDir("auth-attempts");
+    const isolatedBridge = await startBridge({
+      workspaceRoot: isolatedRoot,
+      port: 0,
+      persistRuntime: false,
+      authStoreFile: path.join(isolatedAuth, "store.json"),
+    });
+
+    try {
+      const isolatedBase = isolatedBridge.localBaseUrl();
+      const registration = await fetch(`${isolatedBase}/oauth/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ client_name: "Attempts-Test", redirect_uris: [REDIRECT_URI] }),
+      });
+      const client = (await registration.json()) as { client_id: string };
+      const { challenge } = pkceVerifierAndChallenge();
+      const pairing = isolatedBridge.pairing.create();
+
+      const createRequest = async (): Promise<string> => {
+        const authorizeUrl = new URL(`${isolatedBase}/oauth/authorize`);
+        authorizeUrl.searchParams.set("client_id", client.client_id);
+        authorizeUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+        authorizeUrl.searchParams.set("response_type", "code");
+        authorizeUrl.searchParams.set("code_challenge", challenge);
+        authorizeUrl.searchParams.set("code_challenge_method", "S256");
+        const response = await fetch(authorizeUrl, { redirect: "manual" });
+        const html = await response.text();
+        const requestId = html.match(/name="request_id" value="([a-f0-9]+)"/)?.[1];
+        expect(requestId).toBeTruthy();
+        return requestId!;
+      };
+      const submit = (requestId: string, code: string): Promise<Response> =>
+        fetch(`${isolatedBase}/oauth/authorize`, {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ request_id: requestId, pairing_code: code }),
+          redirect: "manual",
+        });
+
+      const exhaustedRequest = await createRequest();
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        const response = await submit(exhaustedRequest, "AAAA-AAAA");
+        expect(response.status).toBe(attempt < 5 ? 401 : 410);
+      }
+
+      const independentRequest = await createRequest();
+      const success = await submit(independentRequest, pairing.code);
+      expect(success.status).toBe(302);
+    } finally {
+      await isolatedBridge.close();
+      cleanup(isolatedRoot);
+      cleanup(isolatedAuth);
+    }
+  });
+
   it("escapes the workspace name in the pairing page", async () => {
     const xssWorkspaceRoot = makeTmpDir("oauth-html");
     write(xssWorkspaceRoot, ".c2c.json", JSON.stringify({ name: "<script>alert('xss')</script>" }));

--- a/tests/pairing.test.ts
+++ b/tests/pairing.test.ts
@@ -67,6 +67,15 @@ describe("PairingManager", () => {
     expect(manager.verify(first.code).ok).toBe(false);
   });
 
+  it("can leave global attempts untouched for request-scoped verification", () => {
+    const manager = new PairingManager("ws1", { maxAttempts: 3, ipRateLimit: 100 });
+    const pairing = manager.create();
+    for (let i = 0; i < 10; i++) {
+      expect(manager.verify("AAAA-AAAA", `10.0.0.${i}`, { consumeFailure: false }).reason).toBe("invalid");
+    }
+    expect(manager.verify(pairing.code).ok).toBe(true);
+  });
+
   it("normalizes input", () => {
     expect(normalizePairingCode(" ab2-cd3 e ")).toBe("AB2CD3E");
     expect(formatPairingCode("ABCDEFGH")).toBe("ABCD-EFGH");


### PR DESCRIPTION
## Summary

- Track failed pairing attempts per pending OAuth authorization request.
- Keep the global pairing session available to other independent authorization requests.
- Invalidate only the request that exhausts its five attempts.

## Context

This is an independent follow-up to #23, split out according to the maintainer's guidance.

## Scope

This PR intentionally does not change credential storage, redirect URI compatibility, or OAuth resource validation.

## Verification

- Focused pairing and OAuth tests: 26 passed.
- Full test suite: 127 passed.
- TypeScript build passed.
