### PR TITLE
fix(mcp): authenticate before parsing JSON

### DIFF
--- a/src/bridge/server.ts
+++ b/src/bridge/server.ts
@@ -128,8 +128,8 @@ export async function startBridge(opts: BridgeOptions): Promise<Bridge> {
   const mcpHandler = createMcpHttpHandler(() => createMcpServer({ workspace, logger }), logger);
   app.all(
     "/mcp",
-    express.json({ limit: "8mb" }),
     bearerAuth({ store: authStore, workspaceId: workspace.id, getBaseUrl, logger }),
+    express.json({ limit: "8mb" }),
     (req: Request, res: Response) => {
       void mcpHandler(req, res);
     }

--- a/tests/oauth.test.ts
+++ b/tests/oauth.test.ts
@@ -273,6 +273,15 @@ describe("token enforcement on /mcp", () => {
     expect(response.headers.get("www-authenticate")).toContain("resource_metadata");
   });
 
+  it("authenticates before parsing an invalid MCP body", async () => {
+    const response = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{" + "x".repeat(100_000),
+    });
+    expect(response.status).toBe(401);
+  });
+
   it("401 with an invalid token", async () => {
     const response = await mcpCall("c2c_at_totally-invalid");
     expect(response.status).toBe(401);


### PR DESCRIPTION
## Summary

- Authenticate `/mcp` requests before running the JSON body parser.
- Reject unauthorized requests without spending work parsing their request bodies.
- Add a regression test using a large invalid JSON body without a bearer token.

## Context

This is an independent follow-up to #23, split out according to the maintainer's guidance.

## Scope

This PR only changes middleware order and its regression test. It does not change OAuth state, credential storage, redirect URI compatibility, or resource validation.

## Verification

- Focused OAuth tests: 17 passed.
- Full test suite: 126 passed.
- TypeScript build passed.
