### PR TITLE
fix: fail closed on unknown bridge state

### DIFF
--- a/bin/c2c.js
+++ b/bin/c2c.js
@@ -8,7 +8,8 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const dist = path.join(here, "..", "dist", "cli", "index.js");
 
 if (existsSync(dist)) {
-  await import(pathToFileURL(dist).href);
+  const { runCli } = await import(pathToFileURL(dist).href);
+  await runCli();
 } else {
   // dev fallback: run TypeScript sources through the tsx ESM loader
   const entry = path.join(here, "..", "src", "cli", "index.ts");

--- a/src/bridge/runtime.ts
+++ b/src/bridge/runtime.ts
@@ -47,31 +47,169 @@ export interface HealthPayload {
   status: string;
 }
 
-/** Probe a port and check whether a healthy c2c bridge for the workspace answers. */
-export async function probeBridge(
+export type BridgeProbeFailureReason =
+  | "probe_failed"
+  | "timeout"
+  | "http_error"
+  | "invalid_response"
+  | "wrong_service";
+
+export type BridgeProbeResult =
+  | { state: "healthy"; health: HealthPayload }
+  | { state: "unknown"; reason: BridgeProbeFailureReason };
+
+function isHealthPayload(value: unknown): value is HealthPayload {
+  if (!value || typeof value !== "object") return false;
+  const body = value as Record<string, unknown>;
+  return (
+    typeof body.service === "string" &&
+    typeof body.version === "string" &&
+    typeof body.workspaceId === "string" &&
+    typeof body.status === "string"
+  );
+}
+
+function probeFailureReason(error: unknown): BridgeProbeFailureReason {
+  return error instanceof Error && error.name === "AbortError" ? "timeout" : "probe_failed";
+}
+
+/** Probe a port without collapsing an inconclusive result into "stopped". */
+export async function probeBridgeState(
   port: number,
   timeoutMs = 2000
-): Promise<HealthPayload | null> {
+): Promise<BridgeProbeResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
     const response = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
+    if (!response.ok) return { state: "unknown", reason: "http_error" };
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      return { state: "unknown", reason: "invalid_response" };
+    }
+    if (!isHealthPayload(body)) return { state: "unknown", reason: "invalid_response" };
+    if (body.service !== SERVICE_NAME) return { state: "unknown", reason: "wrong_service" };
+    return { state: "healthy", health: body };
+  } catch (error) {
+    return { state: "unknown", reason: probeFailureReason(error) };
+  } finally {
     clearTimeout(timer);
-    if (!response.ok) return null;
-    const body = (await response.json()) as HealthPayload;
-    if (body.service !== SERVICE_NAME) return null;
-    return body;
-  } catch {
-    return null;
   }
 }
 
+/**
+ * Compatibility wrapper for callers that have not migrated to the tri-state
+ * API yet. Mutation-sensitive callers must use findBridgeObservation instead.
+ */
+export async function probeBridge(port: number, timeoutMs = 2000): Promise<HealthPayload | null> {
+  const result = await probeBridgeState(port, timeoutMs);
+  return result.state === "healthy" ? result.health : null;
+}
+
+export type BridgeObservation =
+  | { state: "healthy"; runtime: RuntimeState; health: HealthPayload }
+  | {
+      state: "stopped";
+      runtime: RuntimeState | null;
+      reason: "runtime_missing" | "pid_missing";
+    }
+  | {
+      state: "unknown";
+      runtime: RuntimeState | null;
+      reason: BridgeProbeFailureReason | "runtime_unreadable" | "workspace_mismatch";
+    };
+
+type RuntimeReadResult =
+  | { state: "missing" }
+  | { state: "present"; runtime: RuntimeState }
+  | { state: "unreadable" };
+
+function isRuntimeState(value: unknown): value is RuntimeState {
+  if (!value || typeof value !== "object") return false;
+  const state = value as Record<string, unknown>;
+  return (
+    typeof state.service === "string" &&
+    typeof state.version === "string" &&
+    typeof state.workspaceId === "string" &&
+    typeof state.workspaceRoot === "string" &&
+    Number.isInteger(state.pid) &&
+    Number.isInteger(state.port) &&
+    typeof state.adminToken === "string" &&
+    (typeof state.publicUrl === "string" || state.publicUrl === null) &&
+    typeof state.startedAt === "string"
+  );
+}
+
+function readRuntimeStateForObservation(workspaceId: string): RuntimeReadResult {
+  const file = path.join(getStateDir(), "runtime", `${workspaceId}.json`);
+  let contents: string;
+  try {
+    contents = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT" ? { state: "missing" } : { state: "unreadable" };
+  }
+
+  try {
+    const runtime = JSON.parse(contents) as unknown;
+    return isRuntimeState(runtime) && runtime.workspaceId === workspaceId
+      ? { state: "present", runtime }
+      : { state: "unreadable" };
+  } catch {
+    return { state: "unreadable" };
+  }
+}
+
+type PidObservation = "present" | "missing" | "unknown";
+
+function observePid(pid: number): PidObservation {
+  if (!Number.isInteger(pid) || pid <= 0) return "unknown";
+  try {
+    process.kill(pid, 0);
+    return "present";
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ESRCH" ? "missing" : "unknown";
+  }
+}
+
+/**
+ * Observe the bridge with enough context to distinguish stopped from unknown.
+ * Observation is read-only: it never clears runtime state or changes a process.
+ */
+export async function findBridgeObservation(workspaceId: string, timeoutMs = 2000): Promise<BridgeObservation> {
+  const stored = readRuntimeStateForObservation(workspaceId);
+  if (stored.state === "missing") {
+    return { state: "stopped", runtime: null, reason: "runtime_missing" };
+  }
+  if (stored.state === "unreadable") {
+    return { state: "unknown", runtime: null, reason: "runtime_unreadable" };
+  }
+
+  const probe = await probeBridgeState(stored.runtime.port, timeoutMs);
+  if (probe.state === "healthy") {
+    if (probe.health.workspaceId !== workspaceId) {
+      return { state: "unknown", runtime: stored.runtime, reason: "workspace_mismatch" };
+    }
+    return { state: "healthy", runtime: stored.runtime, health: probe.health };
+  }
+
+  return observePid(stored.runtime.pid) === "missing"
+    ? { state: "stopped", runtime: stored.runtime, reason: "pid_missing" }
+    : { state: "unknown", runtime: stored.runtime, reason: probe.reason };
+}
+
+/** Short alias for callers that prefer an observation-oriented name. */
+export const observeBridge = findBridgeObservation;
+
+/**
+ * Compatibility wrapper for the pre-tri-state lifecycle API. It is retained
+ * only while mutation-sensitive callers migrate to findBridgeObservation.
+ */
 export async function findLiveBridge(workspaceId: string): Promise<RuntimeState | null> {
-  const state = readRuntimeState(workspaceId);
-  if (!state) return null;
-  const health = await probeBridge(state.port);
-  if (health && health.workspaceId === workspaceId) return state;
-  return null;
+  const result = await findBridgeObservation(workspaceId);
+  return result.state === "healthy" ? result.runtime : null;
 }
 
 export { SERVICE_NAME, VERSION };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,9 +2,9 @@ import { Command } from "commander";
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { startBridge } from "../bridge/server.js";
-import { findLiveBridge, probeBridge, readRuntimeState, type RuntimeState } from "../bridge/runtime.js";
+import { findBridgeObservation, type BridgeObservation, type RuntimeState } from "../bridge/runtime.js";
 import { adminFetch, ensureBridge, stopBridge } from "../process/daemon.js";
 import { Workspace } from "../workspace/manager.js";
 import { AuthStore } from "../auth/store.js";
@@ -61,6 +61,10 @@ const cross = (msg: string): void => say(`✗ ${msg}`);
 
 function resolveWorkspace(option?: string): string {
   return path.resolve(option ?? process.cwd());
+}
+
+function bridgeStateUnknownError(observation: Extract<BridgeObservation, { state: "unknown" }>, action: string): Error {
+  return new Error(`Bridge state is unknown (${observation.reason}); refusing to ${action}.`);
 }
 
 function persistWorkspaceEndpoint(opts: {
@@ -334,12 +338,22 @@ program
   .action(async (opts: { workspace?: string; json: boolean }) => {
     const root = resolveWorkspace(opts.workspace);
     const workspace = new Workspace(root);
-    const runtime = await findLiveBridge(workspace.id);
-    if (!runtime) {
+    const observation = await findBridgeObservation(workspace.id);
+    if (observation.state === "unknown") {
+      if (opts.json) {
+        say(JSON.stringify({ ok: false, state: "unknown", running: null, reason: observation.reason }));
+      } else {
+        cross(`Bridge 状态无法确认（${observation.reason}），未将其视为未运行。`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    if (observation.state === "stopped") {
       if (opts.json) say(JSON.stringify({ ok: false, running: false }));
       else say("Bridge 未运行。使用 `c2c start` 启动。");
       return;
     }
+    const runtime = observation.runtime;
     const info = await adminFetch<AdminInfo>(runtime, "GET", "/admin/info");
     if (opts.json) {
       say(JSON.stringify({ ok: true, running: true, ...info }));
@@ -402,13 +416,23 @@ program
 
     // Bridge
     let runtime: RuntimeState | null = null;
+    let bridgeUnknown = false;
     if (workspace) {
-      runtime = await findLiveBridge(workspace.id);
-      if (!runtime && opts.fix) {
+      const observation = await findBridgeObservation(workspace.id);
+      if (observation.state === "healthy") {
+        runtime = observation.runtime;
+      } else if (observation.state === "unknown") {
+        bridgeUnknown = true;
+        report.bridge = {
+          ok: false,
+          detail: `状态无法确认（${observation.reason}），未执行自动修复`,
+        };
+      } else if (opts.fix) {
         try {
           runtime = (await ensureBridge(root)).runtime;
           results.push("已自动启动 Bridge");
         } catch (error) {
+          bridgeUnknown = true;
           report.bridge = { ok: false, detail: (error as Error).message };
         }
       }
@@ -475,105 +499,115 @@ program
     };
 
     if (runtime) {
-      let info = await adminFetch<AdminInfo>(runtime, "GET", "/admin/info");
+      let activeRuntime = runtime;
+      let info = await adminFetch<AdminInfo>(activeRuntime, "GET", "/admin/info");
       if (namedReady && opts.fix && info.tunnel.provider !== "cloudflare-named") {
         await stopBridge(root);
+        runtime = null;
         await new Promise((resolve) => setTimeout(resolve, 400));
         try {
-          runtime = (await ensureBridge(root)).runtime;
-          info = await adminFetch<AdminInfo>(runtime, "GET", "/admin/info");
+          activeRuntime = (await ensureBridge(root)).runtime;
+          runtime = activeRuntime;
+          info = await adminFetch<AdminInfo>(activeRuntime, "GET", "/admin/info");
           results.push("已切换到固定域名连接");
         } catch (error) {
+          runtime = null;
+          bridgeUnknown = true;
+          report.bridge = { ok: false, detail: (error as Error).message };
           report.tunnel = { ok: false, detail: (error as Error).message };
         }
       }
-      const expectedPublic = Boolean(lastEndpoint?.publicUrl) || namedReady;
-      let currentUrl = info.publicUrl ?? info.tunnel.url;
-      let healthy = false;
-      if (currentUrl) {
-        try {
-          const response = await fetch(`${currentUrl}/health`, { signal: AbortSignal.timeout(8000) });
-          healthy = response.ok;
-        } catch {
-          healthy = false;
+      if (!bridgeUnknown) {
+        const expectedPublic = Boolean(lastEndpoint?.publicUrl) || namedReady;
+        let currentUrl = info.publicUrl ?? info.tunnel.url;
+        let healthy = false;
+        if (currentUrl) {
+          try {
+            const response = await fetch(`${currentUrl}/health`, { signal: AbortSignal.timeout(8000) });
+            healthy = response.ok;
+          } catch {
+            healthy = false;
+          }
         }
-      }
 
-      if ((!currentUrl || !healthy) && opts.fix && (expectedPublic || info.tunnel.running)) {
-        try {
-          const binaries = detectTunnelBinaries();
-          if (!binaries.cloudflared) {
-            report.tunnel = { ok: false, detail: "NEED_CLOUDFLARED" };
-          } else {
-            const started = await adminFetch<TunnelStartResponse>(runtime, "POST", "/admin/tunnel/start", 90_000);
-            if (started.url) {
-              const previousUrl = lastEndpoint?.publicUrl;
-              currentUrl = started.url;
-              healthy = true;
-              info = await adminFetch<AdminInfo>(runtime, "GET", "/admin/info");
-              const sameAddress =
-                previousUrl && normalizePublicUrl(previousUrl) === normalizePublicUrl(started.url);
-              results.push(sameAddress ? "已重新建立安全连接" : "已重新建立安全连接（地址已更换）");
+        if ((!currentUrl || !healthy) && opts.fix && (expectedPublic || info.tunnel.running)) {
+          try {
+            const binaries = detectTunnelBinaries();
+            if (!binaries.cloudflared) {
+              report.tunnel = { ok: false, detail: "NEED_CLOUDFLARED" };
+            } else {
+              const started = await adminFetch<TunnelStartResponse>(activeRuntime, "POST", "/admin/tunnel/start", 90_000);
+              if (started.url) {
+                const previousUrl = lastEndpoint?.publicUrl;
+                currentUrl = started.url;
+                healthy = true;
+                info = await adminFetch<AdminInfo>(activeRuntime, "GET", "/admin/info");
+                const sameAddress =
+                  previousUrl && normalizePublicUrl(previousUrl) === normalizePublicUrl(started.url);
+                results.push(sameAddress ? "已重新建立安全连接" : "已重新建立安全连接（地址已更换）");
+              }
+            }
+          } catch (error) {
+            report.tunnel = { ok: false, detail: (error as Error).message };
+          }
+        }
+
+        if (currentUrl && healthy) {
+          report.tunnel = { ok: true, detail: currentUrl };
+          const nextMcp = mcpUrlFromPublic(currentUrl);
+          const action = connectorAction(lastEndpoint?.mcpUrl, nextMcp);
+          const boundName = nextMcp
+            ? persistWorkspaceEndpoint({
+                workspaceId: info.workspaceId,
+                workspaceName: info.workspaceName,
+                port: activeRuntime.port,
+                publicUrl: currentUrl,
+                mcpUrl: nextMcp,
+                previous: lastEndpoint,
+              })
+            : connectorName;
+          chatgptRepair = {
+            ...chatgptRepair,
+            needed: action === "update",
+            reason: action === "update" ? "address_reclaimed" : undefined,
+            connectorAction: action,
+            connectorName: boundName,
+            userMessage: action === "update" ? reclaimUserMessage(boundName) : undefined,
+            mcpUrl: nextMcp,
+            previousMcpUrl: lastEndpoint?.mcpUrl ?? null,
+          };
+          if (action === "update") {
+            try {
+              const pairing = await adminFetch<PairingResponse>(activeRuntime, "POST", "/admin/pairing");
+              chatgptRepair.pairingCode = pairing.code;
+              chatgptRepair.pairingExpiresAt = pairing.expiresAt;
+              results.push(`已生成新的配对码，需要更新「${boundName}」`);
+            } catch (error) {
+              report.oauth = { ok: false, detail: (error as Error).message };
             }
           }
-        } catch (error) {
-          report.tunnel = { ok: false, detail: (error as Error).message };
+        } else if (namedReady) {
+          report.tunnel = report.tunnel ?? { ok: false, detail: "NAMED_TUNNEL_DOWN" };
+          namedRepair = { needed: true, userMessage: NAMED_REPAIR_MESSAGE };
+        } else if (expectedPublic) {
+          report.tunnel = report.tunnel ?? { ok: false, detail: "安全连接未恢复" };
+          chatgptRepair = {
+            ...chatgptRepair,
+            needed: true,
+            reason: "address_reclaimed",
+            connectorAction: "update",
+            connectorName,
+            userMessage: reclaimUserMessage(connectorName),
+            mcpUrl: null,
+          };
+        } else if (!currentUrl) {
+          report.tunnel = { ok: true, detail: "未启用（本地模式）" };
+        } else {
+          report.tunnel = { ok: false, detail: "公网地址无法访问" };
         }
       }
-
-      if (currentUrl && healthy) {
-        report.tunnel = { ok: true, detail: currentUrl };
-        const nextMcp = mcpUrlFromPublic(currentUrl);
-        const action = connectorAction(lastEndpoint?.mcpUrl, nextMcp);
-        const boundName = nextMcp
-          ? persistWorkspaceEndpoint({
-              workspaceId: info.workspaceId,
-              workspaceName: info.workspaceName,
-              port: runtime.port,
-              publicUrl: currentUrl,
-              mcpUrl: nextMcp,
-              previous: lastEndpoint,
-            })
-          : connectorName;
-        chatgptRepair = {
-          ...chatgptRepair,
-          needed: action === "update",
-          reason: action === "update" ? "address_reclaimed" : undefined,
-          connectorAction: action,
-          connectorName: boundName,
-          userMessage: action === "update" ? reclaimUserMessage(boundName) : undefined,
-          mcpUrl: nextMcp,
-          previousMcpUrl: lastEndpoint?.mcpUrl ?? null,
-        };
-        if (action === "update") {
-          try {
-            const pairing = await adminFetch<PairingResponse>(runtime, "POST", "/admin/pairing");
-            chatgptRepair.pairingCode = pairing.code;
-            chatgptRepair.pairingExpiresAt = pairing.expiresAt;
-            results.push(`已生成新的配对码，需要更新「${boundName}」`);
-          } catch (error) {
-            report.oauth = { ok: false, detail: (error as Error).message };
-          }
-        }
-      } else if (namedReady) {
-        report.tunnel = report.tunnel ?? { ok: false, detail: "NAMED_TUNNEL_DOWN" };
-        namedRepair = { needed: true, userMessage: NAMED_REPAIR_MESSAGE };
-      } else if (expectedPublic) {
-        report.tunnel = report.tunnel ?? { ok: false, detail: "安全连接未恢复" };
-        chatgptRepair = {
-          ...chatgptRepair,
-          needed: true,
-          reason: "address_reclaimed",
-          connectorAction: "update",
-          connectorName,
-          userMessage: reclaimUserMessage(connectorName),
-          mcpUrl: null,
-        };
-      } else if (!currentUrl) {
-        report.tunnel = { ok: true, detail: "未启用（本地模式）" };
-      } else {
-        report.tunnel = { ok: false, detail: "公网地址无法访问" };
-      }
+    } else if (bridgeUnknown) {
+      report.tunnel = report.tunnel ?? { ok: false, detail: "Bridge 状态无法确认，未执行安全连接或连接器修复" };
     } else if (namedReady) {
       report.tunnel = { ok: false, detail: "NAMED_TUNNEL_DOWN" };
       namedRepair = { needed: true, userMessage: NAMED_REPAIR_MESSAGE };
@@ -591,6 +625,9 @@ program
 
     if (opts.json) {
       say(JSON.stringify({ report, repairs: results, chatgptRepair, namedRepair }));
+      if (Object.values(report).some((value) => !value.ok) || chatgptRepair.needed || namedRepair.needed) {
+        process.exitCode = 1;
+      }
       return;
     }
     say(`${PRODUCT_NAME} Doctor`);
@@ -665,9 +702,12 @@ program
   .action(async (opts: { workspace?: string }) => {
     const root = resolveWorkspace(opts.workspace);
     const workspace = new Workspace(root);
-    const runtime = await findLiveBridge(workspace.id);
-    if (runtime) {
-      await adminFetch(runtime, "POST", "/admin/revoke-all");
+    const observation = await findBridgeObservation(workspace.id);
+    if (observation.state === "unknown") {
+      throw bridgeStateUnknownError(observation, "revoke access");
+    }
+    if (observation.state === "healthy") {
+      await adminFetch(observation.runtime, "POST", "/admin/revoke-all");
     } else {
       // bridge not running: revoke directly in the persisted store
       new AuthStore(workspace.id).revokeAll();
@@ -964,10 +1004,14 @@ tunnelCmd
       const mode = opts.mode.trim().toLowerCase();
       const previous = readTunnelState(workspace.id);
       if (mode === "quick") {
-        const state = chooseQuickTunnel(workspace.id);
-        if (await findLiveBridge(workspace.id)) {
-          if (previous.preference === "named") await stopBridge(root);
+        const observation = await findBridgeObservation(workspace.id);
+        if (observation.state === "unknown") {
+          throw bridgeStateUnknownError(observation, "change tunnel configuration");
         }
+        if (observation.state === "healthy" && previous.preference === "named") {
+          await stopBridge(root);
+        }
+        const state = chooseQuickTunnel(workspace.id);
         const payload = { ...tunnelChoicePayload(workspace), state };
         if (opts.json) say(JSON.stringify(payload));
         else check("已选用临时地址");
@@ -991,6 +1035,11 @@ tunnelCmd
         say(payload.userMessage);
         return;
       }
+      const observation = await findBridgeObservation(workspace.id);
+      if (observation.state === "unknown") {
+        throw bridgeStateUnknownError(observation, "change tunnel configuration");
+      }
+      if (observation.state === "healthy") await stopBridge(root);
       if (!opts.json) say(NAMED_LOGIN_PROMPT);
       const result = await provisionNamedTunnel({
         workspaceId: workspace.id,
@@ -998,7 +1047,6 @@ tunnelCmd
         zone,
         hostname: opts.hostname,
       });
-      if (await findLiveBridge(workspace.id)) await stopBridge(root);
       const payload = {
         ...tunnelChoicePayload(workspace),
         ok: true,
@@ -1051,7 +1099,13 @@ function handleCliError(error: unknown, json: boolean): void {
   process.exitCode = 1;
 }
 
-program.parseAsync(process.argv).catch((error: Error) => {
-  cross(error.message);
-  process.exit(1);
-});
+export async function runCli(argv: string[] = process.argv): Promise<void> {
+  await program.parseAsync(argv);
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  runCli().catch((error: Error) => {
+    cross(error.message);
+    process.exit(1);
+  });
+}

--- a/src/process/daemon.ts
+++ b/src/process/daemon.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDir, getStateDir } from "../config/paths.js";
-import { findLiveBridge, probeBridge, readRuntimeState, type RuntimeState } from "../bridge/runtime.js";
+import { findBridgeObservation, type RuntimeState } from "../bridge/runtime.js";
 import { Workspace } from "../workspace/manager.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -31,8 +31,11 @@ export interface EnsureBridgeResult {
  */
 export async function ensureBridge(workspaceRoot: string, opts: { port?: number } = {}): Promise<EnsureBridgeResult> {
   const workspace = new Workspace(workspaceRoot);
-  const live = await findLiveBridge(workspace.id);
-  if (live) return { runtime: live, spawned: false };
+  const observation = await findBridgeObservation(workspace.id);
+  if (observation.state === "healthy") return { runtime: observation.runtime, spawned: false };
+  if (observation.state === "unknown") {
+    throw new Error(`Bridge state is unknown (${observation.reason}); refusing to start another bridge.`);
+  }
 
   const logDir = ensureDir(path.join(getStateDir(), "logs"));
   const logFile = path.join(logDir, `bridge-${workspace.id}.out.log`);
@@ -60,8 +63,8 @@ export async function ensureBridge(workspaceRoot: string, opts: { port?: number 
   const deadline = Date.now() + 20_000;
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 300));
-    const runtime = await findLiveBridge(workspace.id);
-    if (runtime) return { runtime, spawned: true };
+    const readiness = await findBridgeObservation(workspace.id);
+    if (readiness.state === "healthy") return { runtime: readiness.runtime, spawned: true };
     if (child.exitCode !== null && child.exitCode !== 0) {
       throw new Error(`Bridge process exited with code ${child.exitCode}. See ${logFile}`);
     }
@@ -95,19 +98,20 @@ export async function adminFetch<T = unknown>(
 
 export async function stopBridge(workspaceRoot: string): Promise<boolean> {
   const workspace = new Workspace(workspaceRoot);
-  const runtime = readRuntimeState(workspace.id);
-  if (!runtime) return false;
-  const healthy = await probeBridge(runtime.port);
-  if (healthy && healthy.workspaceId === workspace.id) {
-    try {
-      await adminFetch(runtime, "POST", "/admin/shutdown", 5000);
-      return true;
-    } catch {
-      // fall through to kill
-    }
+  const observation = await findBridgeObservation(workspace.id);
+  if (observation.state === "stopped") return false;
+  if (observation.state === "unknown") {
+    throw new Error(`Bridge state is unknown (${observation.reason}); refusing to stop a bridge.`);
+  }
+
+  try {
+    await adminFetch(observation.runtime, "POST", "/admin/shutdown", 5000);
+    return true;
+  } catch {
+    // fall through to kill only after a positively healthy observation
   }
   try {
-    process.kill(runtime.pid, "SIGTERM");
+    process.kill(observation.runtime.pid, "SIGTERM");
     return true;
   } catch {
     return false;

--- a/tests/bin.test.ts
+++ b/tests/bin.test.ts
@@ -1,0 +1,30 @@
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { cleanup, makeTmpDir } from "./helpers.js";
+
+describe("c2c bin wrapper", () => {
+  it("runs the CLI exported by a built installation", () => {
+    const root = makeTmpDir("bin-wrapper");
+
+    try {
+      mkdirSync(path.join(root, "bin"), { recursive: true });
+      mkdirSync(path.join(root, "dist", "cli"), { recursive: true });
+      copyFileSync(path.resolve("bin/c2c.js"), path.join(root, "bin", "c2c.js"));
+      writeFileSync(path.join(root, "package.json"), JSON.stringify({ type: "module" }));
+      writeFileSync(
+        path.join(root, "dist", "cli", "index.js"),
+        'export async function runCli() { process.stdout.write("CLI_RAN\\n"); }\n'
+      );
+
+      const result = spawnSync(process.execPath, [path.join(root, "bin", "c2c.js")], { encoding: "utf8" });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("CLI_RAN\n");
+    } finally {
+      cleanup(root);
+    }
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BridgeObservation, RuntimeState } from "../src/bridge/runtime.js";
+import { findBridgeObservation } from "../src/bridge/runtime.js";
+import { adminFetch, ensureBridge, stopBridge } from "../src/process/daemon.js";
+import { ensureSandboxAllowlist } from "../src/config/sandbox-allow.js";
+import { writeLastEndpoint } from "../src/config/endpoint.js";
+import { chooseQuickTunnel, provisionNamedTunnel } from "../src/tunnel/named-provision.js";
+import { writeTunnelState } from "../src/tunnel/state.js";
+import { Workspace } from "../src/workspace/manager.js";
+import { cleanup, isolateStateDir, makeTmpDir } from "./helpers.js";
+
+vi.mock("../src/bridge/runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/bridge/runtime.js")>("../src/bridge/runtime.js");
+  return { ...actual, findBridgeObservation: vi.fn() };
+});
+
+vi.mock("../src/process/daemon.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/process/daemon.js")>("../src/process/daemon.js");
+  return {
+    ...actual,
+    adminFetch: vi.fn(),
+    ensureBridge: vi.fn(),
+    stopBridge: vi.fn(),
+  };
+});
+
+vi.mock("../src/config/sandbox-allow.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/config/sandbox-allow.js")>(
+    "../src/config/sandbox-allow.js"
+  );
+  return { ...actual, ensureSandboxAllowlist: vi.fn() };
+});
+
+vi.mock("../src/tunnel/named-provision.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/tunnel/named-provision.js")>(
+    "../src/tunnel/named-provision.js"
+  );
+  return { ...actual, chooseQuickTunnel: vi.fn(), provisionNamedTunnel: vi.fn() };
+});
+
+const { runCli } = await import("../src/cli/index.js");
+const observeMock = vi.mocked(findBridgeObservation);
+const adminFetchMock = vi.mocked(adminFetch);
+const ensureBridgeMock = vi.mocked(ensureBridge);
+const stopBridgeMock = vi.mocked(stopBridge);
+const sandboxMock = vi.mocked(ensureSandboxAllowlist);
+const chooseQuickTunnelMock = vi.mocked(chooseQuickTunnel);
+const provisionNamedTunnelMock = vi.mocked(provisionNamedTunnel);
+const temporaryDirs: string[] = [];
+
+function runtimeFor(root: string): RuntimeState {
+  return {
+    service: "codex-bridge",
+    version: "test",
+    workspaceId: new Workspace(root).id,
+    workspaceRoot: root,
+    pid: process.pid,
+    port: 48765,
+    adminToken: "test-admin-token",
+    publicUrl: null,
+    startedAt: new Date(0).toISOString(),
+  };
+}
+
+function healthy(root: string): BridgeObservation {
+  const runtime = runtimeFor(root);
+  return {
+    state: "healthy",
+    runtime,
+    health: { service: runtime.service, version: runtime.version, workspaceId: runtime.workspaceId, status: "ok" },
+  };
+}
+
+function stopped(): BridgeObservation {
+  return { state: "stopped", runtime: null, reason: "runtime_missing" };
+}
+
+function unknown(reason: "probe_failed" | "runtime_unreadable" = "probe_failed"): BridgeObservation {
+  return { state: "unknown", runtime: null, reason };
+}
+
+function track(name: string): string {
+  const root = makeTmpDir(name);
+  temporaryDirs.push(root);
+  return root;
+}
+
+function captureOutput(): () => string {
+  let output = "";
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    output += String(chunk);
+    return true;
+  });
+  return () => output;
+}
+
+beforeEach(() => {
+  isolateStateDir();
+  process.exitCode = 0;
+  sandboxMock.mockReturnValue({
+    added: false,
+    alreadyAllowed: true,
+    stateDir: "/isolated/c2c-state",
+    configPath: "/isolated/codex-config.toml",
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  while (temporaryDirs.length) cleanup(temporaryDirs.pop()!);
+});
+
+describe("CLI bridge observation safety", () => {
+  it("reports status unknown instead of claiming the bridge is stopped", async () => {
+    const root = track("cli-status-unknown");
+    observeMock.mockResolvedValueOnce(unknown());
+    const output = captureOutput();
+
+    await runCli(["node", "c2c", "status", "--workspace", root, "--json"]);
+
+    expect(JSON.parse(output())).toMatchObject({ ok: false, state: "unknown", running: null, reason: "probe_failed" });
+    expect(adminFetchMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("preserves the stopped status result", async () => {
+    const root = track("cli-status-stopped");
+    observeMock.mockResolvedValueOnce(stopped());
+    const output = captureOutput();
+
+    await runCli(["node", "c2c", "status", "--workspace", root, "--json"]);
+
+    expect(JSON.parse(output())).toEqual({ ok: false, running: false });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("does not auto-repair or propose connector repair when doctor cannot observe the bridge", async () => {
+    const root = track("cli-doctor-unknown");
+    const workspace = new Workspace(root);
+    writeLastEndpoint({
+      workspaceId: workspace.id,
+      port: 48765,
+      publicUrl: "https://old.example.com",
+      mcpUrl: "https://old.example.com/mcp",
+      connectorName: "Codex with ChatGPT · test",
+    });
+    writeTunnelState({
+      workspaceId: workspace.id,
+      preference: "named",
+      askedAt: new Date(0).toISOString(),
+      tunnelName: "test-tunnel",
+      hostname: "c2c-test.example.com",
+    });
+    observeMock.mockResolvedValueOnce(unknown("runtime_unreadable"));
+    const output = captureOutput();
+
+    await runCli(["node", "c2c", "doctor", "--workspace", root, "--json"]);
+
+    const payload = JSON.parse(output());
+    expect(payload.report.bridge).toMatchObject({ ok: false });
+    expect(payload.report.bridge.detail).toContain("状态无法确认");
+    expect(payload.report.tunnel).toMatchObject({ ok: false });
+    expect(payload.chatgptRepair.needed).toBe(false);
+    expect(payload.namedRepair.needed).toBe(false);
+    expect(ensureBridgeMock).not.toHaveBeenCalled();
+    expect(adminFetchMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses quick tunnel changes when bridge state is unknown", async () => {
+    const root = track("cli-tunnel-quick-unknown");
+    observeMock.mockResolvedValueOnce(unknown());
+    const output = captureOutput();
+
+    await runCli(["node", "c2c", "tunnel", "choose", "--mode", "quick", "--workspace", root, "--json"]);
+
+    expect(JSON.parse(output())).toMatchObject({ ok: false });
+    expect(chooseQuickTunnelMock).not.toHaveBeenCalled();
+    expect(stopBridgeMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses named tunnel provisioning when bridge state is unknown", async () => {
+    const root = track("cli-tunnel-named-unknown");
+    observeMock.mockResolvedValueOnce(unknown());
+    const output = captureOutput();
+
+    await runCli([
+      "node",
+      "c2c",
+      "tunnel",
+      "choose",
+      "--mode",
+      "named",
+      "--zone",
+      "example.com",
+      "--workspace",
+      root,
+      "--json",
+    ]);
+
+    expect(JSON.parse(output())).toMatchObject({ ok: false });
+    expect(provisionNamedTunnelMock).not.toHaveBeenCalled();
+    expect(stopBridgeMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses unpair when bridge state is unknown", async () => {
+    const root = track("cli-unpair-unknown");
+    observeMock.mockResolvedValueOnce(unknown());
+
+    await expect(runCli(["node", "c2c", "unpair", "--workspace", root])).rejects.toThrow(
+      /Bridge state is unknown.*refusing to revoke access/
+    );
+
+    expect(adminFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps healthy status behavior and reads admin info only after a healthy observation", async () => {
+    const root = track("cli-status-healthy");
+    const observation = healthy(root);
+    observeMock.mockResolvedValueOnce(observation);
+    adminFetchMock.mockResolvedValueOnce({
+      workspaceId: observation.runtime.workspaceId,
+      workspaceName: "test-workspace",
+      workspaceRoot: root,
+      port: observation.runtime.port,
+      publicUrl: null,
+      tunnel: { running: false, url: null, provider: "none" },
+      tokenCount: 1,
+      pairingActive: false,
+      pid: observation.runtime.pid,
+      startedAt: observation.runtime.startedAt,
+    });
+    const output = captureOutput();
+
+    await runCli(["node", "c2c", "status", "--workspace", root, "--json"]);
+
+    expect(JSON.parse(output())).toMatchObject({ ok: true, running: true, workspaceName: "test-workspace" });
+    expect(adminFetchMock).toHaveBeenCalledWith(observation.runtime, "GET", "/admin/info");
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { findBridgeObservation, SERVICE_NAME, VERSION, type BridgeObservation, type RuntimeState } from "../src/bridge/runtime.js";
+import { ensureBridge, stopBridge } from "../src/process/daemon.js";
+import { Workspace } from "../src/workspace/manager.js";
+import { cleanup, isolateStateDir, makeTmpDir } from "./helpers.js";
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn: vi.fn() };
+});
+
+vi.mock("../src/bridge/runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/bridge/runtime.js")>("../src/bridge/runtime.js");
+  return { ...actual, findBridgeObservation: vi.fn() };
+});
+
+const spawnMock = vi.mocked(spawn);
+const observeMock = vi.mocked(findBridgeObservation);
+const temporaryDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  while (temporaryDirs.length) cleanup(temporaryDirs.pop()!);
+});
+
+function runtimeFor(root: string): RuntimeState {
+  return {
+    service: SERVICE_NAME,
+    version: VERSION,
+    workspaceId: new Workspace(root).id,
+    workspaceRoot: root,
+    pid: process.pid,
+    port: 48765,
+    adminToken: "test-admin-token",
+    publicUrl: null,
+    startedAt: new Date(0).toISOString(),
+  };
+}
+
+function healthy(root: string): BridgeObservation {
+  const runtime = runtimeFor(root);
+  return {
+    state: "healthy",
+    runtime,
+    health: { service: SERVICE_NAME, version: VERSION, workspaceId: runtime.workspaceId, status: "ok" },
+  };
+}
+
+function stopped(): BridgeObservation {
+  return { state: "stopped", runtime: null, reason: "runtime_missing" };
+}
+
+function unknown(): BridgeObservation {
+  return { state: "unknown", runtime: null, reason: "runtime_unreadable" };
+}
+
+function makeChild(): ChildProcess {
+  return { exitCode: null, unref: vi.fn() } as unknown as ChildProcess;
+}
+
+describe("daemon lifecycle safety", () => {
+  it("reuses an observed healthy bridge without spawning", async () => {
+    const root = makeTmpDir("daemon-healthy");
+    temporaryDirs.push(root);
+    const observation = healthy(root);
+    observeMock.mockResolvedValueOnce(observation);
+
+    await expect(ensureBridge(root)).resolves.toEqual({ runtime: observation.runtime, spawned: false });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to spawn when bridge state is unknown", async () => {
+    const root = makeTmpDir("daemon-unknown");
+    temporaryDirs.push(root);
+    observeMock.mockResolvedValueOnce(unknown());
+
+    await expect(ensureBridge(root)).rejects.toThrow(/state is unknown.*refusing to start/i);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("spawns once after a definite stopped observation", async () => {
+    const root = makeTmpDir("daemon-stopped");
+    temporaryDirs.push(root);
+    const observation = healthy(root);
+    observeMock.mockResolvedValueOnce(stopped()).mockResolvedValueOnce(observation);
+    spawnMock.mockReturnValue(makeChild());
+
+    await expect(ensureBridge(root)).resolves.toEqual({ runtime: observation.runtime, spawned: true });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not signal a bridge that is definitely stopped", async () => {
+    const root = makeTmpDir("stop-stopped");
+    temporaryDirs.push(root);
+    observeMock.mockResolvedValueOnce(stopped());
+    const kill = vi.spyOn(process, "kill");
+    const fetch = vi.spyOn(globalThis, "fetch");
+
+    await expect(stopBridge(root)).resolves.toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("refuses to stop a bridge when state is unknown", async () => {
+    const root = makeTmpDir("stop-unknown");
+    temporaryDirs.push(root);
+    observeMock.mockResolvedValueOnce(unknown());
+    const kill = vi.spyOn(process, "kill");
+    const fetch = vi.spyOn(globalThis, "fetch");
+
+    await expect(stopBridge(root)).rejects.toThrow(/state is unknown.*refusing to stop/i);
+    expect(kill).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses authenticated shutdown for an observed healthy bridge", async () => {
+    const root = makeTmpDir("stop-healthy");
+    temporaryDirs.push(root);
+    observeMock.mockResolvedValueOnce(healthy(root));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    const kill = vi.spyOn(process, "kill");
+
+    await expect(stopBridge(root)).resolves.toBe(true);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("only falls back to SIGTERM after a healthy observation", async () => {
+    const root = makeTmpDir("stop-fallback");
+    temporaryDirs.push(root);
+    const observation = healthy(root);
+    observeMock.mockResolvedValueOnce(observation);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("shutdown unavailable"));
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+
+    await expect(stopBridge(root)).resolves.toBe(true);
+    expect(kill).toHaveBeenCalledWith(observation.runtime.pid, "SIGTERM");
+  });
+});

--- a/tests/port.test.ts
+++ b/tests/port.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
 import { startBridge } from "../src/bridge/server.js";
-import { probeBridge } from "../src/bridge/runtime.js";
+import { probeBridgeState } from "../src/bridge/runtime.js";
 import { makeTmpDir, cleanup, write, isolateStateDir } from "./helpers.js";
 
 describe("port collision handling", () => {
@@ -31,11 +31,14 @@ describe("port collision handling", () => {
     expect(bridgeB.port).toBeGreaterThan(0);
 
     // health identifies each bridge's workspace, so callers can detect reuse
-    const healthA = await probeBridge(bridgeA.port);
-    const healthB = await probeBridge(bridgeB.port);
-    expect(healthA?.workspaceId).toBe(bridgeA.workspace.id);
-    expect(healthB?.workspaceId).toBe(bridgeB.workspace.id);
-    expect(healthA?.workspaceId).not.toBe(healthB?.workspaceId);
+    const healthA = await probeBridgeState(bridgeA.port);
+    const healthB = await probeBridgeState(bridgeB.port);
+    expect(healthA.state).toBe("healthy");
+    expect(healthB.state).toBe("healthy");
+    if (healthA.state !== "healthy" || healthB.state !== "healthy") throw new Error("expected healthy probes");
+    expect(healthA.health.workspaceId).toBe(bridgeA.workspace.id);
+    expect(healthB.health.workspaceId).toBe(bridgeB.workspace.id);
+    expect(healthA.health.workspaceId).not.toBe(healthB.health.workspaceId);
 
     await bridgeA.close();
     await bridgeB.close();

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  findBridgeObservation,
+  SERVICE_NAME,
+  VERSION,
+  writeRuntimeState,
+  type RuntimeState,
+} from "../src/bridge/runtime.js";
+import { cleanup, isolateStateDir } from "./helpers.js";
+
+const stateDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (stateDirs.length) cleanup(stateDirs.pop()!);
+});
+
+function runtime(workspaceId: string, pid = process.pid): RuntimeState {
+  return {
+    service: SERVICE_NAME,
+    version: VERSION,
+    workspaceId,
+    workspaceRoot: "/tmp/c2c-runtime-test",
+    pid,
+    port: 48765,
+    adminToken: "test-token",
+    publicUrl: null,
+    startedAt: new Date(0).toISOString(),
+  };
+}
+
+describe("tri-state bridge observation", () => {
+  it("reports a missing runtime record as stopped", async () => {
+    stateDirs.push(isolateStateDir());
+
+    await expect(findBridgeObservation("missing-workspace")).resolves.toEqual({
+      state: "stopped",
+      runtime: null,
+      reason: "runtime_missing",
+    });
+  });
+
+  it("reports a failed probe as unknown when the recorded process still exists", async () => {
+    stateDirs.push(isolateStateDir());
+    writeRuntimeState(runtime("probe-failed"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("loopback denied"));
+
+    await expect(findBridgeObservation("probe-failed")).resolves.toMatchObject({
+      state: "unknown",
+      reason: "probe_failed",
+    });
+  });
+
+  it("keeps PID inspection failures unknown", async () => {
+    stateDirs.push(isolateStateDir());
+    writeRuntimeState(runtime("pid-inaccessible"));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("probe failed"));
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    });
+
+    await expect(findBridgeObservation("pid-inaccessible")).resolves.toMatchObject({
+      state: "unknown",
+      reason: "probe_failed",
+    });
+  });
+
+  it("reports a positively absent recorded process as stopped", async () => {
+    stateDirs.push(isolateStateDir());
+    writeRuntimeState(runtime("stale-runtime", 999_999_999));
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("probe failed"));
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+
+    await expect(findBridgeObservation("stale-runtime")).resolves.toMatchObject({
+      state: "stopped",
+      reason: "pid_missing",
+    });
+  });
+});


### PR DESCRIPTION
## Problem

**Primary fix: P1 — merge blocker.**

Bridge probe uncertainty could be collapsed into “stopped”. Under restricted or inconclusive probe conditions, this could trigger unintended recovery actions such as restarting the bridge, changing a Quick Tunnel address, or requesting connector repair.

## Why this PR

This PR introduces explicit tri-state bridge observation:

- `healthy`
- `stopped`
- `unknown`

`unknown` now fails closed instead of being treated as `stopped`. Mutation-sensitive daemon and CLI paths only perform recovery when the bridge is positively known to be stopped.

## Impact

The user-visible risk was that an inconclusive local probe could be reported as “Bridge not running”, causing automatic recovery and potentially changing the public endpoint used by the ChatGPT connector.

The affected paths now refuse to:

- spawn, stop, or signal a bridge on unknown state;
- change or provision tunnel configuration on unknown state;
- perform connector or saved-address repair based on an assumed stopped state.

## Risk assessment

The change is limited to bridge observation, daemon lifecycle handling, CLI recovery decisions, and focused tests.

The existing fixed-domain tunnel implementation was not added or redesigned.

Verification completed successfully:

- Full Vitest: 143 passed
- Typecheck passed
- Build passed
- `git diff --check` passed
- CLI entrypoint smoke test passed

## Benefits

- Prevents probe uncertainty from causing state-changing recovery.
- Preserves normal healthy and stopped behavior.
- Makes status and doctor distinguish uncertainty from an actually stopped bridge.
- Reduces unnecessary Quick Tunnel address changes and connector repair.

## Maintenance

Keep future lifecycle decisions based on explicit bridge observations. Do not reintroduce nullable bridge wrappers at mutation-sensitive call sites.

A follow-up may add single-flight protection for concurrent bridge startup and explicit shutdown/read-back confirmation for restart flows.
