### PR TITLE
Make Windows Quick Tunnel startup fail closed

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,6 +68,8 @@ macOS: `brew install cloudflared`
 Windows: `winget install Cloudflare.cloudflared`
 Linux: see Cloudflare's package instructions.
 The Skill installs this automatically during setup.
+If cloudflared is installed in a custom location that is not on `PATH`, set
+`C2C_CLOUDFLARED_PATH` to the executable's absolute path before running `c2c`.
 
 ### Every new Codex chat “repairs” the connection / cannot write logs
 The C2C state directory lives outside the project (macOS:

--- a/src/tunnel/cloudflared.ts
+++ b/src/tunnel/cloudflared.ts
@@ -2,15 +2,63 @@ import { spawn, type ChildProcess } from "node:child_process";
 import readline from "node:readline";
 import type { Logger } from "../logger/index.js";
 import { nullLogger } from "../logger/index.js";
+import { SERVICE_NAME } from "../version.js";
 import { findBinary } from "./detect.js";
 import type { TunnelDoctorReport, TunnelProvider, TunnelStatus } from "./provider.js";
 
-const QUICK_TUNNEL_URL_RE = /https:\/\/[a-z0-9][a-z0-9-]*\.trycloudflare\.com/i;
+const QUICK_TUNNEL_URL_RE = /https:\/\/[^\s|]+/gi;
+const QUICK_TUNNEL_HOST_RE = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\.trycloudflare\.com$/i;
+const HEALTH_CHECK_INTERVAL_MS = 250;
+const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+
+function isBridgeHealth(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+  const health = payload as Record<string, unknown>;
+  return health.service === SERVICE_NAME && health.status === "ok";
+}
+
+async function bridgeHealth(
+  fetchImpl: NonNullable<CloudflaredQuickTunnelOptions["fetchImpl"]>,
+  publicUrl: string
+): Promise<{ ready: boolean; detail: string }> {
+  const response = await fetchImpl(new URL("/health", publicUrl).toString(), {
+    redirect: "error",
+    signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+  });
+  if (!response) return { ready: false, detail: "Health check did not run" };
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    return { ready: false, detail: `Health check returned HTTP ${response.status}` };
+  }
+  return {
+    ready: isBridgeHealth(await response.json().catch(() => null)),
+    detail: `Health check did not identify ${SERVICE_NAME}`,
+  };
+}
 
 /** Extract a Quick Tunnel public URL from a cloudflared log line. */
 export function parseQuickTunnelUrl(line: string): string | null {
-  const match = line.match(QUICK_TUNNEL_URL_RE);
-  return match ? match[0] : null;
+  for (const match of line.matchAll(QUICK_TUNNEL_URL_RE)) {
+    try {
+      const url = new URL(match[0]);
+      if (url.protocol !== "https:" || !QUICK_TUNNEL_HOST_RE.test(url.hostname)) continue;
+      if (url.hostname.toLowerCase() === "api.trycloudflare.com") continue;
+      return url.origin;
+    } catch {
+      // Ignore malformed URLs embedded in log output.
+    }
+  }
+  return null;
+}
+
+export interface CloudflaredQuickTunnelOptions {
+  startTimeoutMs?: number;
+  spawnImpl?: (
+    command: string,
+    args: string[],
+    options: { stdio: ["ignore", "pipe", "pipe"] }
+  ) => ChildProcess;
+  fetchImpl?: (input: string | URL, init?: RequestInit) => Promise<Response>;
 }
 
 /**
@@ -23,11 +71,21 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
   private child: ChildProcess | null = null;
   private url: string | null = null;
   private lastError: string | null = null;
+  private readonly startTimeoutMs: number;
+  private readonly spawnImpl: NonNullable<CloudflaredQuickTunnelOptions["spawnImpl"]>;
+  private readonly fetchImpl: NonNullable<CloudflaredQuickTunnelOptions["fetchImpl"]>;
+  private starting: Promise<string> | null = null;
+  private cancelStart: (() => void) | null = null;
 
   constructor(
     private readonly logger: Logger = nullLogger,
-    private readonly binaryOverride?: string
-  ) {}
+    private readonly binaryOverride?: string,
+    options: CloudflaredQuickTunnelOptions = {}
+  ) {
+    this.startTimeoutMs = options.startTimeoutMs ?? 45_000;
+    this.spawnImpl = options.spawnImpl ?? ((command, args, spawnOptions) => spawn(command, args, spawnOptions));
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => fetch(input, init));
+  }
 
   private binary(): string | null {
     return this.binaryOverride ?? findBinary("cloudflared");
@@ -35,41 +93,144 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
 
   async start(localPort: number): Promise<string> {
     if (this.child && this.url) return this.url;
+    if (this.starting) return this.starting;
+    const starting = this.startProcess(localPort);
+    this.starting = starting;
+    try {
+      return await starting;
+    } finally {
+      if (this.starting === starting) this.starting = null;
+    }
+  }
+
+  private startProcess(localPort: number): Promise<string> {
     const bin = this.binary();
     if (!bin) {
-      throw new Error(
-        "cloudflared is not installed. Install it (e.g. `brew install cloudflared`) and retry."
+      return Promise.reject(
+        new Error(
+          "cloudflared is not installed. Install it (e.g. `brew install cloudflared`) and retry."
+        )
       );
     }
+
     return new Promise<string>((resolve, reject) => {
-      const child = spawn(
-        bin,
-        ["tunnel", "--url", `http://127.0.0.1:${localPort}`, "--no-autoupdate"],
-        { stdio: ["ignore", "pipe", "pipe"] }
-      );
+      let child: ChildProcess;
+      try {
+        child = this.spawnImpl(
+          bin,
+          ["tunnel", "--url", `http://127.0.0.1:${localPort}`, "--no-autoupdate"],
+          { stdio: ["ignore", "pipe", "pipe"] }
+        );
+      } catch (error) {
+        reject(error);
+        return;
+      }
       this.child = child;
       this.url = null;
       this.lastError = null;
+      let settled = false;
+      let candidateUrl: string | null = null;
+      let cancel: (() => void) | null = null;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
 
-      const timeout = setTimeout(() => {
-        if (!this.url) {
-          this.logger.error("Quick tunnel did not produce a URL within 45s");
+      const closeReaders = (): void => {
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+      };
+
+      const isAlive = (): boolean => this.child === child;
+
+      const stopChild = (): void => {
+        try {
           child.kill("SIGTERM");
-          reject(new Error("Tunnel start timed out"));
+        } catch {
+          // The process may have exited between the state check and kill().
         }
-      }, 45_000);
+      };
+
+      const finish = (callback: () => void, closeOutput = true): void => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        if (closeOutput) closeReaders();
+        if (cancel && this.cancelStart === cancel) this.cancelStart = null;
+        callback();
+      };
+
+      const fail = (error: unknown): void => {
+        finish(() => {
+          stopChild();
+          if (this.child === child) {
+            this.child = null;
+            this.url = null;
+          }
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
+      };
+
+      cancel = () => fail(new Error("Tunnel start stopped"));
+      this.cancelStart = cancel;
+
+      const ready = (url: string): void => {
+        if (!isAlive()) {
+          fail(new Error("cloudflared exited before the public health endpoint became ready"));
+          return;
+        }
+        finish(
+          () => {
+            this.url = url;
+            this.lastError = null;
+            this.logger.info(`Quick tunnel established: ${url}`);
+            resolve(url);
+          },
+          false
+        );
+      };
+
+      const waitForHealth = async (): Promise<void> => {
+        const publicUrl = candidateUrl;
+        if (!publicUrl) return;
+        while (!settled) {
+          if (!isAlive()) {
+            fail(new Error("cloudflared exited before the public health endpoint became ready"));
+            return;
+          }
+
+          try {
+            const result = await bridgeHealth(this.fetchImpl, publicUrl);
+            if (settled) return;
+            if (result.ready) {
+              ready(publicUrl);
+              return;
+            }
+            this.lastError = result.detail;
+          } catch (error) {
+            if (settled) return;
+            this.lastError = error instanceof Error ? error.message : String(error);
+          }
+          if (settled) return;
+          await new Promise((resolveWait) => setTimeout(resolveWait, HEALTH_CHECK_INTERVAL_MS));
+        }
+      };
+
+      timeout = setTimeout(() => {
+        if (!settled) {
+          this.logger.error(`Quick tunnel did not become ready within ${this.startTimeoutMs}ms`);
+          fail(new Error("Tunnel start timed out"));
+        }
+      }, this.startTimeoutMs);
 
       const scan = (stream: NodeJS.ReadableStream): void => {
         const rl = readline.createInterface({ input: stream });
         rl.on("line", (line) => {
           const url = parseQuickTunnelUrl(line);
-          if (url && !this.url) {
-            this.url = url;
-            clearTimeout(timeout);
-            this.logger.info(`Quick tunnel established: ${url}`);
-            resolve(url);
+          if (url && !candidateUrl) {
+            candidateUrl = url;
+            void waitForHealth().catch((error) => {
+              this.logger.error(`Quick tunnel health check failed: ${String(error)}`);
+            });
           }
-          if (/error/i.test(line)) {
+          if (/\b(?:ERR|error|failed|fatal)\b/i.test(line)) {
             this.lastError = line.slice(0, 400);
             this.logger.debug(`cloudflared: ${line.slice(0, 400)}`);
           }
@@ -79,29 +240,44 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
       if (child.stderr) scan(child.stderr);
 
       child.on("error", (error) => {
-        clearTimeout(timeout);
-        this.child = null;
-        reject(error);
+        closeReaders();
+        if (this.child === child) {
+          this.child = null;
+          this.url = null;
+        }
+        if (!settled) fail(error);
       });
       child.on("exit", (code) => {
-        clearTimeout(timeout);
-        const wasStarting = this.url === null;
+        closeReaders();
+        if (this.child === child) {
+          this.child = null;
+          this.url = null;
+          this.lastError = `cloudflared exited (code ${code})`;
+        }
         this.logger.warn(`cloudflared exited with code ${code}`);
-        this.child = null;
-        this.url = null;
-        if (wasStarting) {
-          reject(new Error(`cloudflared exited (code ${code}) before establishing a tunnel${this.lastError ? `: ${this.lastError}` : ""}`));
+        if (!settled) {
+          fail(
+            new Error(
+              `cloudflared exited (code ${code}) before establishing a tunnel${this.lastError ? `: ${this.lastError}` : ""}`
+            )
+          );
         }
       });
     });
   }
 
   async stop(): Promise<void> {
+    this.cancelStart?.();
     if (this.child) {
-      this.child.kill("SIGTERM");
+      try {
+        this.child.kill("SIGTERM");
+      } catch {
+        // The process may have exited between the state check and kill().
+      }
       this.child = null;
     }
     this.url = null;
+    this.lastError = null;
   }
 
   async restart(localPort: number): Promise<string> {

--- a/src/tunnel/detect.ts
+++ b/src/tunnel/detect.ts
@@ -11,9 +11,24 @@ const COMMON_DIRS = [
   "C:\\Program Files (x86)\\cloudflared",
 ];
 
+function accessibleFile(candidate: string): string | null {
+  try {
+    const resolved = path.resolve(candidate);
+    if (!fs.statSync(resolved).isFile()) return null;
+    fs.accessSync(resolved, fs.constants.F_OK | fs.constants.X_OK);
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
 /** Locate a binary on PATH or in common install locations. */
 export function findBinary(name: string): string | null {
   const exe = process.platform === "win32" ? `${name}.exe` : name;
+  if (name === "cloudflared" && process.env.C2C_CLOUDFLARED_PATH?.trim()) {
+    const configured = accessibleFile(process.env.C2C_CLOUDFLARED_PATH.trim());
+    if (configured) return configured;
+  }
   try {
     const probe = spawnSync(exe, ["--version"], { stdio: "ignore", timeout: 5000 });
     if (probe.status === 0 || probe.status === 1) return exe; // on PATH
@@ -22,14 +37,8 @@ export function findBinary(name: string): string | null {
   }
   for (const dir of COMMON_DIRS) {
     const full = path.join(dir, exe);
-    try {
-      if (fs.existsSync(full)) {
-        fs.accessSync(full, fs.constants.X_OK);
-        return full;
-      }
-    } catch {
-      // try next
-    }
+    const configured = accessibleFile(full);
+    if (configured) return configured;
   }
   return null;
 }

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { parseQuickTunnelUrl } from "../src/tunnel/cloudflared.js";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import type { ChildProcess } from "node:child_process";
+import { PassThrough } from "node:stream";
+import { findBinary } from "../src/tunnel/detect.js";
+import {
+  CloudflaredQuickTunnel,
+  parseQuickTunnelUrl,
+  type CloudflaredQuickTunnelOptions,
+} from "../src/tunnel/cloudflared.js";
 import { normalizeNamedTunnelHostname } from "../src/tunnel/cloudflared-named.js";
 import { hostnameSlug, parseZoneInput, suggestedNamedHostname } from "../src/tunnel/hostname.js";
 import {
@@ -11,31 +20,186 @@ import {
   type CloudflaredAccount,
 } from "../src/tunnel/named-provision.js";
 import { isNamedTunnelReady, needsTunnelChoice, readTunnelState } from "../src/tunnel/state.js";
-import { cleanup, isolateStateDir } from "./helpers.js";
+import { cleanup, isolateStateDir, makeTmpDir, write } from "./helpers.js";
 
 const stateDirs: string[] = [];
 const previousStateDir = process.env.C2C_STATE_DIR;
+const previousCloudflaredPath = process.env.C2C_CLOUDFLARED_PATH;
+const QUICK_URL = "https://random-words-here-1234.trycloudflare.com";
+type FetchImpl = NonNullable<CloudflaredQuickTunnelOptions["fetchImpl"]>;
+
+class FakeCloudflaredProcess extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  readonly kill = vi.fn(() => {
+    this.killed = true;
+    return true;
+  });
+}
+
+function setupTunnel(fetchImpl: FetchImpl, startTimeoutMs = 1_000) {
+  const child = new FakeCloudflaredProcess();
+  const spawnImpl = vi.fn(() => child as unknown as ChildProcess);
+  const tunnel = new CloudflaredQuickTunnel(undefined, "cloudflared", {
+    spawnImpl,
+    fetchImpl,
+    startTimeoutMs,
+  });
+  return { child, spawnImpl, tunnel };
+}
+
+function announceUrl(child: FakeCloudflaredProcess): void {
+  child.stderr.write(`INF ${QUICK_URL}\n`);
+}
+
+function healthResponse(): Response {
+  return new Response(JSON.stringify({ service: "c2c-bridge", status: "ok" }), { status: 200 });
+}
 
 afterEach(() => {
   while (stateDirs.length) cleanup(stateDirs.pop()!);
   if (previousStateDir === undefined) delete process.env.C2C_STATE_DIR;
   else process.env.C2C_STATE_DIR = previousStateDir;
+  if (previousCloudflaredPath === undefined) delete process.env.C2C_CLOUDFLARED_PATH;
+  else process.env.C2C_CLOUDFLARED_PATH = previousCloudflaredPath;
+});
+
+describe("findBinary", () => {
+  it("uses C2C_CLOUDFLARED_PATH for an accessible cloudflared executable", () => {
+    const dir = makeTmpDir("cloudflared-path");
+    stateDirs.push(dir);
+    const filename = process.platform === "win32" ? "cloudflared.exe" : "cloudflared";
+    const configured = write(dir, filename, "placeholder");
+    if (process.platform !== "win32") fs.chmodSync(configured, 0o755);
+    process.env.C2C_CLOUDFLARED_PATH = configured;
+    expect(findBinary("cloudflared")).toBe(configured);
+  });
 });
 
 describe("parseQuickTunnelUrl", () => {
   it("extracts the URL from cloudflared banner output", () => {
     const line =
       "2026-08-28T10:00:00Z INF |  https://random-words-here-1234.trycloudflare.com                              |";
-    expect(parseQuickTunnelUrl(line)).toBe("https://random-words-here-1234.trycloudflare.com");
+    expect(parseQuickTunnelUrl(line)).toBe(QUICK_URL);
   });
 
-  it("ignores unrelated lines", () => {
+  it("ignores unrelated lines and non-Quick-Tunnel hosts", () => {
     expect(parseQuickTunnelUrl("INF Starting tunnel connection")).toBeNull();
     expect(parseQuickTunnelUrl("visit https://www.cloudflare.com for docs")).toBeNull();
+    expect(parseQuickTunnelUrl("https://evil.example.com/trycloudflare.com")).toBeNull();
   });
 
-  it("does not match non-trycloudflare hosts", () => {
-    expect(parseQuickTunnelUrl("https://evil.example.com/trycloudflare.com")).toBeNull();
+  it("rejects Cloudflare's API host", () => {
+    expect(parseQuickTunnelUrl("INF https://api.trycloudflare.com")).toBeNull();
+  });
+});
+
+describe("CloudflaredQuickTunnel", () => {
+  it("resolves only after the public health endpoint identifies the bridge", async () => {
+    const fetchImpl = vi.fn(async () => healthResponse());
+    const { child, spawnImpl, tunnel } = setupTunnel(fetchImpl);
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+
+    await expect(starting).resolves.toBe(QUICK_URL);
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "cloudflared",
+      ["tunnel", "--url", "http://127.0.0.1:3333", "--no-autoupdate"],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(`${QUICK_URL}/health`, {
+      redirect: "error",
+      signal: expect.any(AbortSignal),
+    });
+    expect(tunnel.status()).toMatchObject({ running: true, url: QUICK_URL });
+    await tunnel.stop();
+  });
+
+  it("keeps consuming cloudflared errors after the tunnel is ready", async () => {
+    const { child, tunnel } = setupTunnel(async () => healthResponse());
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+    await expect(starting).resolves.toBe(QUICK_URL);
+
+    child.stderr.write("ERR runtime connection error\n");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(tunnel.status().detail).toBe("ERR runtime connection error");
+    await tunnel.stop();
+  });
+
+  it("does not accept an HTTP 200 response from another service", async () => {
+    const { child, tunnel } = setupTunnel(
+      async () =>
+        new Response(JSON.stringify({ service: "cloudflare", status: "ok" }), { status: 200 }),
+      20
+    );
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+
+    await expect(starting).rejects.toThrow(/timed out/i);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(tunnel.status()).toMatchObject({ running: false, url: null });
+  });
+
+  it("does not spawn twice or resolve a stopped pending start", async () => {
+    const { child, spawnImpl, tunnel } = setupTunnel(() => new Promise<Response>(() => {}));
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const concurrent = tunnel.start(3333);
+    await tunnel.stop();
+    await expect(starting).rejects.toThrow(/stopped/i);
+    await expect(concurrent).rejects.toThrow(/stopped/i);
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("does not resolve if cloudflared exits while the health probe is in flight", async () => {
+    let resolveFetch!: (response: Response) => void;
+    const { child, tunnel } = setupTunnel(
+      () => new Promise<Response>((resolve) => (resolveFetch = resolve))
+    );
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    child.exitCode = 1;
+    child.emit("exit", 1, null);
+    resolveFetch(healthResponse());
+    await expect(starting).rejects.toThrow(/exited/i);
+    expect(tunnel.status()).toMatchObject({ running: false, url: null });
+  });
+
+  it("rejects when spawning reports an asynchronous error", async () => {
+    const { child, tunnel } = setupTunnel(async () => new Response(null));
+    const starting = tunnel.start(3333);
+    await new Promise((resolve) => setImmediate(resolve));
+    child.emit("error", new Error("spawn cloudflared ENOENT"));
+
+    await expect(starting).rejects.toThrow(/ENOENT/i);
+    expect(tunnel.status()).toMatchObject({ running: false, url: null });
+  });
+
+  it("retries a non-ready health response before resolving", async () => {
+    let calls = 0;
+    const cancelBody = vi.fn(async () => undefined);
+    const { child, tunnel } = setupTunnel(async () => {
+      calls += 1;
+      return calls === 1
+        ? ({ ok: false, status: 503, body: { cancel: cancelBody } } as unknown as Response)
+        : healthResponse();
+    });
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+
+    await expect(starting).resolves.toBe(QUICK_URL);
+    expect(calls).toBe(2);
+    expect(cancelBody).toHaveBeenCalledTimes(1);
+    await tunnel.stop();
   });
 });
 


### PR DESCRIPTION
Fixes #59.

## Summary

- Add `C2C_CLOUDFLARED_PATH` for explicitly selecting a custom Windows `cloudflared` executable.
- Parse Quick Tunnel URLs strictly and reject Cloudflare's reserved `api.trycloudflare.com` host.
- Treat startup as successful only after the public `/health` endpoint identifies the C2C Bridge and returns `status: "ok"`.
- Fail closed when `cloudflared` exits early, the health check never becomes valid, startup times out, or startup is stopped.

The implementation uses the existing `TunnelProvider` interface and standard `fetch`/`AbortSignal` behavior. It adds no new dependencies and does not change the MCP tool surface.

## Validation

- `pnpm test` — 154/154 tests passed.
- `pnpm typecheck` — passed.
- `pnpm build` — passed.
- `pnpm audit --prod --audit-level high` — no known vulnerabilities.
- `git diff --check` — passed.

Windows smoke test:

- Downloaded the official `cloudflared` `2026.8.3` Windows AMD64 binary and verified its SHA-256 digest.
- Started a real Quick Tunnel through this provider.
- Public `/health` returned `{ "service": "c2c-bridge", "status": "ok" }` after roughly 10 seconds.
- Stopped the tunnel and confirmed there was no remaining `cloudflared` process.
