### PR TITLE
Make secure JSON state writes atomic

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
+import { randomUUID } from "node:crypto";
 
 /**
  * State directory resolution, following OS conventions.
@@ -33,13 +34,43 @@ export function stateSubdir(name: string): string {
 
 /** Write a JSON file with owner-only permissions. */
 export function writeSecureJson(file: string, data: unknown): void {
+  const payload = JSON.stringify(data, null, 2);
   ensureDir(path.dirname(file));
-  fs.writeFileSync(file, JSON.stringify(data, null, 2), { mode: 0o600 });
+  const temp = `${file}.${process.pid}-${randomUUID()}.tmp`;
   try {
-    fs.chmodSync(file, 0o600);
-  } catch {
-    // best effort on platforms without chmod semantics
+    const fd = fs.openSync(temp, "wx", 0o600);
+    try {
+      fs.writeFileSync(fd, payload);
+      fs.fdatasyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    renameWithRetry(temp, file);
+  } finally {
+    try {
+      fs.rmSync(temp, { force: true });
+    } catch {
+      // best effort; rename success already removed the temporary file
+    }
   }
+}
+
+function renameWithRetry(temp: string, file: string): void {
+  let lastError: unknown;
+  const sleeper = new Int32Array(new SharedArrayBuffer(4));
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      fs.renameSync(temp, file);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EPERM" && code !== "EACCES" && code !== "EBUSY" && code !== "EEXIST") throw error;
+      lastError = error;
+      // Synchronous backoff for Windows sharing violations.
+      Atomics.wait(sleeper, 0, 0, 10 * 2 ** attempt);
+    }
+  }
+  throw lastError;
 }
 
 export function readJsonIfExists<T>(file: string): T | null {

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readJsonIfExists, writeSecureJson } from "../src/config/paths.js";
+import { cleanup, makeTmpDir } from "./helpers.js";
+
+describe("writeSecureJson", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    while (dirs.length) cleanup(dirs.pop()!);
+  });
+
+  it("writes JSON and leaves no temporary file", () => {
+    const dir = makeTmpDir("secure-json");
+    dirs.push(dir);
+    const file = path.join(dir, "state", "session.json");
+
+    writeSecureJson(file, { ok: true, value: 42 });
+
+    expect(readJsonIfExists(file)).toEqual({ ok: true, value: 42 });
+    expect(fs.readdirSync(path.dirname(file))).toEqual(["session.json"]);
+  });
+
+  it("replaces the previous state file without leaving temporary files", () => {
+    const dir = makeTmpDir("secure-json-replace");
+    dirs.push(dir);
+    const file = path.join(dir, "state.json");
+
+    writeSecureJson(file, { version: 1 });
+    writeSecureJson(file, { version: 2 });
+
+    expect(readJsonIfExists(file)).toEqual({ version: 2 });
+    expect(fs.readdirSync(dir)).toEqual(["state.json"]);
+  });
+
+  it("keeps the previous file when serialization fails", () => {
+    const dir = makeTmpDir("secure-json-failure");
+    dirs.push(dir);
+    const file = path.join(dir, "state.json");
+    fs.writeFileSync(file, JSON.stringify({ version: 1 }), { mode: 0o600 });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => writeSecureJson(file, circular)).toThrow(TypeError);
+
+    expect(readJsonIfExists(file)).toEqual({ version: 1 });
+    expect(fs.readdirSync(dir)).toEqual(["state.json"]);
+  });
+
+  it("keeps the previous file and removes the temporary file when the rename swap fails", () => {
+    const dir = makeTmpDir("secure-json-swap-failure");
+    dirs.push(dir);
+    const file = path.join(dir, "state.json");
+    writeSecureJson(file, { version: 1 });
+    const rename = vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
+      throw new Error("simulated swap failure");
+    });
+
+    expect(() => writeSecureJson(file, { version: 2 })).toThrow(/simulated swap failure/);
+
+    expect(readJsonIfExists(file)).toEqual({ version: 1 });
+    expect(fs.readdirSync(dir)).toEqual(["state.json"]);
+    rename.mockRestore();
+  });
+
+  it.skipIf(process.platform === "win32")("creates owner-only files on POSIX", () => {
+    const dir = makeTmpDir("secure-json-mode");
+    dirs.push(dir);
+    const file = path.join(dir, "state.json");
+
+    writeSecureJson(file, { ok: true });
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
## Summary

- `writeSecureJson()` previously overwrote state files directly. A crash or forced shutdown during writing could leave truncated JSON, causing auth state, session checkpoints, tunnel state, runtime state, endpoint state, UI preferences, and execution output indexes to be silently reset.
- It now serializes first, writes a unique `0600` temporary file in the same directory, flushes the data, and atomically renames it over the target file.
- Transient Windows rename conflicts are retried briefly. Temporary files are removed if any step fails.
- No dependencies, public interfaces, or MCP tool behavior are changed.

## 中文摘要

- 原实现直接覆盖写入状态 JSON。进程崩溃或被强制终止时，可能留下半截 JSON；读取失败后会导致登录状态、会话 checkpoint、隧道状态等被静默重置。
- 现在改为：先序列化，再写入同目录唯一 `0600` 临时文件，刷盘后原子替换目标文件。
- 对 Windows 上短暂的文件占用冲突做少量重试；失败时清理临时文件。
- 不新增依赖，不改变接口，不改变 MCP 工具行为。

## Verification

- `corepack pnpm test` — 158 passed, 1 skipped on Windows
- `corepack pnpm typecheck` — passed
- `corepack pnpm build` — passed
- `corepack pnpm audit --prod --audit-level high` — no known vulnerabilities
- `git diff --check` — passed
