### PR TITLE
Fix noun/verb confusion: login fails → the login fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If you have a Cloudflare account and a domain already on Cloudflare, first-time
 setup (and the next coding session, once) will ask whether you want a stable
 hostname such as `c2c-<project>.your-domain.com`. That path opens a browser so
 you can authorize Cloudflare. After that, the ChatGPT connector keeps working
-across restarts. If you skip it, or login fails, Codex stays on the temporary
+across restarts. If you skip it, or the login fails, Codex stays on the temporary
 address — same features, just a slower repair.
 
 Credentials stay in the OS app state directory, not in the project.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 140).

## Problem

'login fails' uses the noun form where a verb phrase is needed; reads awkwardly.

The problematic text:

```markdown
If you skip it, or login fails, Codex stays on the temporary
```

## Fix

Replaced with:

```markdown
If you skip it, or the login fails, Codex stays on the temporary
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text