### PR TITLE
Add structured output schema for execution_output

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,11 +15,16 @@ const UNTRUSTED_NOTE =
 
 type ToolResult = {
   content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
 
 function ok(data: unknown): ToolResult {
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function okStructured<T extends Record<string, unknown>>(data: T): ToolResult {
+  return { ...ok(data), structuredContent: data };
 }
 
 function fail(code: string, message: string): ToolResult {
@@ -285,6 +290,32 @@ export function createMcpServer(ctx: McpContext): McpServer {
         id: z.number().int().positive().optional(),
         limit: z.number().int().min(1).max(50).default(20),
       },
+      outputSchema: {
+        action: z.enum(["list", "read"]).describe("The operation represented by this result"),
+        items: z
+          .array(
+            z.object({
+              id: z.number().int().positive(),
+              command: z.string(),
+              exitCode: z.number().int().nullable(),
+              timestamp: z.string(),
+              taskId: z.string().nullable(),
+              iteration: z.number().int().nullable(),
+              readable: z.boolean(),
+              status: z.enum(["readable", "restricted"]),
+              truncated: z.boolean(),
+              sizeBytes: z.number().int().nonnegative(),
+            })
+          )
+          .optional()
+          .describe("Recorded output metadata returned by the list operation"),
+        id: z.number().int().positive().optional(),
+        command: z.string().optional(),
+        exitCode: z.number().int().nullable().optional(),
+        timestamp: z.string().optional(),
+        truncated: z.boolean().optional(),
+        text: z.string().optional().describe("Sanitized command output returned by the read operation"),
+      },
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
@@ -304,7 +335,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
           truncated: item.truncated,
           sizeBytes: item.sizeBytes,
         }));
-        return ok({ items });
+        return okStructured({ action: "list", items });
       }
       if (args.id === undefined) return fail("INVALID_ARGUMENTS", "read requires id");
       const result = readExecutionOutput(workspace.id, args.id);
@@ -314,7 +345,8 @@ export function createMcpServer(ctx: McpContext): McpServer {
         }
         return fail("NOT_FOUND", `No execution output with id ${args.id}.`);
       }
-      return ok({
+      return okStructured({
+        action: "read",
         id: result.meta.id,
         command: result.meta.command,
         exitCode: result.meta.exitCode,

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -74,6 +74,17 @@ describe("MCP tools over Streamable HTTP", () => {
     for (const forbidden of ["write_file", "delete_file", "execute_shell", "git_commit", "install_package"]) {
       expect(names).not.toContain(forbidden);
     }
+
+    const executionOutput = tools.find((tool) => tool.name === "execution_output");
+    expect(executionOutput?.outputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        items: { type: "array" },
+        text: { type: "string" },
+      },
+      required: ["action"],
+    });
   });
 
   it("workspace_info returns identity and project detection", async () => {
@@ -188,16 +199,27 @@ describe("MCP tools over Streamable HTTP", () => {
       raw: "-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----",
       exitCode: 0,
     });
-    const list = jsonOf<{ items: { id: number; status: string; command: string; text?: string }[] }>(
-      await client.callTool({ name: "execution_output", arguments: { action: "list" } })
-    );
+    const listResult = await client.callTool({
+      name: "execution_output",
+      arguments: { action: "list" },
+    });
+    const list = jsonOf<{
+      action: "list";
+      items: { id: number; status: string; command: string; text?: string }[];
+    }>(listResult);
+    expect(listResult.structuredContent).toEqual(list);
+    expect(list.action).toBe("list");
     expect(list.items.some((item) => item.id === readable.id && item.status === "readable")).toBe(true);
     expect(list.items.some((item) => item.id === hidden.id && item.status === "restricted")).toBe(true);
     expect(list.items.every((item) => item.text === undefined)).toBe(true);
 
-    const body = jsonOf<{ text: string }>(
-      await client.callTool({ name: "execution_output", arguments: { action: "read", id: readable.id } })
-    );
+    const readResult = await client.callTool({
+      name: "execution_output",
+      arguments: { action: "read", id: readable.id },
+    });
+    const body = jsonOf<{ action: "read"; text: string }>(readResult);
+    expect(readResult.structuredContent).toEqual(body);
+    expect(body.action).toBe("read");
     expect(body.text).toContain("AssertionError");
 
     const denied = await client.callTool({

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -108,7 +108,7 @@ describe("CloudflaredQuickTunnel", () => {
     expect(spawnImpl).toHaveBeenCalledWith(
       "cloudflared",
       ["tunnel", "--url", "http://127.0.0.1:3333", "--no-autoupdate"],
-      { stdio: ["ignore", "pipe", "pipe"] }
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
     );
     expect(fetchImpl).toHaveBeenCalledWith(`${QUICK_URL}/health`, {
       redirect: "error",


### PR DESCRIPTION
## Summary

- advertise an MCP output schema for both execution_output actions
- return matching structuredContent while retaining the existing text content
- cover the advertised schema and list/read structured results in integration tests
- update the stale quick-tunnel spawn expectation for windowsHide: true introduced by 0b70588

## Testing

- corepack pnpm test (154 tests)
- corepack pnpm typecheck
- corepack pnpm build
- git diff --check
