### PR TITLE
Add structured output schemas for MCP tools

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,11 +15,16 @@ const UNTRUSTED_NOTE =
 
 type ToolResult = {
   content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
 
 function ok(data: unknown): ToolResult {
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function okStructured<T extends Record<string, unknown>>(data: T): ToolResult {
+  return { ...ok(data), structuredContent: data };
 }
 
 function fail(code: string, message: string): ToolResult {
@@ -285,6 +290,32 @@ export function createMcpServer(ctx: McpContext): McpServer {
         id: z.number().int().positive().optional(),
         limit: z.number().int().min(1).max(50).default(20),
       },
+      outputSchema: {
+        action: z.enum(["list", "read"]).describe("The operation represented by this result"),
+        items: z
+          .array(
+            z.object({
+              id: z.number().int().positive(),
+              command: z.string(),
+              exitCode: z.number().int().nullable(),
+              timestamp: z.string(),
+              taskId: z.string().nullable(),
+              iteration: z.number().int().nullable(),
+              readable: z.boolean(),
+              status: z.enum(["readable", "restricted"]),
+              truncated: z.boolean(),
+              sizeBytes: z.number().int().nonnegative(),
+            })
+          )
+          .optional()
+          .describe("Recorded output metadata returned by the list operation"),
+        id: z.number().int().positive().optional(),
+        command: z.string().optional(),
+        exitCode: z.number().int().nullable().optional(),
+        timestamp: z.string().optional(),
+        truncated: z.boolean().optional(),
+        text: z.string().optional().describe("Sanitized command output returned by the read operation"),
+      },
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
@@ -304,7 +335,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
           truncated: item.truncated,
           sizeBytes: item.sizeBytes,
         }));
-        return ok({ items });
+        return okStructured({ action: "list", items });
       }
       if (args.id === undefined) return fail("INVALID_ARGUMENTS", "read requires id");
       const result = readExecutionOutput(workspace.id, args.id);
@@ -314,7 +345,8 @@ export function createMcpServer(ctx: McpContext): McpServer {
         }
         return fail("NOT_FOUND", `No execution output with id ${args.id}.`);
       }
-      return ok({
+      return okStructured({
+        action: "read",
         id: result.meta.id,
         command: result.meta.command,
         exitCode: result.meta.exitCode,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,8 +23,8 @@ function ok(data: unknown): ToolResult {
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
 }
 
-function okStructured<T extends Record<string, unknown>>(data: T): ToolResult {
-  return { ...ok(data), structuredContent: data };
+function okStructured<T extends object>(data: T): ToolResult {
+  return { ...ok(data), structuredContent: data as Record<string, unknown> };
 }
 
 function fail(code: string, message: string): ToolResult {
@@ -48,6 +48,145 @@ function requireScope(authInfo: AuthInfo | undefined, scope: string): ToolResult
   return null;
 }
 
+const gitIdentityOutputSchema = z.object({
+  isRepo: z.boolean(),
+  branch: z.string().nullable(),
+  commit: z.string().nullable(),
+  dirty: z.boolean(),
+});
+
+const workspaceInfoOutputSchema = {
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  rootAlias: z.string(),
+  projectType: z.string(),
+  languages: z.array(z.string()),
+  frameworks: z.array(z.string()),
+  packageManager: z.string().nullable(),
+  scripts: z.record(z.string()),
+  git: gitIdentityOutputSchema,
+};
+
+const directoryEntryOutputSchema = z.object({
+  path: z.string(),
+  type: z.enum(["file", "dir"]),
+  sizeBytes: z.number().int().nonnegative().optional(),
+});
+
+const listDirectoryOutputSchema = {
+  path: z.string(),
+  entries: z.array(directoryEntryOutputSchema),
+  total: z.number().int().nonnegative(),
+  offset: z.number().int().nonnegative(),
+  limit: z.number().int().positive(),
+  hasMore: z.boolean(),
+};
+
+const readFileOutputSchema = {
+  path: z.string(),
+  sizeBytes: z.number().int().nonnegative(),
+  totalLines: z.number().int().nonnegative(),
+  startLine: z.number().int().positive(),
+  endLine: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+  remainingLines: z.number().int().nonnegative(),
+  nextStartLine: z.number().int().positive().nullable(),
+  content: z.string(),
+};
+
+const searchMatchOutputSchema = z.object({
+  path: z.string(),
+  line: z.number().int().nonnegative(),
+  text: z.string(),
+});
+
+const searchWorkspaceOutputSchema = {
+  matches: z.array(searchMatchOutputSchema),
+  matchCount: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+  engine: z.enum(["ripgrep", "node"]),
+};
+
+const gitChangeOutputSchema = z.object({
+  path: z.string(),
+  change: z.string(),
+});
+
+const gitStatusOutputSchema = {
+  isRepo: z.boolean(),
+  branch: z.string().nullable(),
+  upstream: z.string().nullable(),
+  ahead: z.number().int().nonnegative(),
+  behind: z.number().int().nonnegative(),
+  staged: z.array(gitChangeOutputSchema),
+  unstaged: z.array(gitChangeOutputSchema),
+  untracked: z.array(z.string()),
+  conflicted: z.array(z.string()),
+};
+
+const gitDiffOutputSchema = {
+  isRepo: z.boolean(),
+  mode: z.enum(["unstaged", "staged", "head"]),
+  totalBytes: z.number().int().nonnegative(),
+  offset: z.number().int().nonnegative(),
+  returnedBytes: z.number().int().nonnegative(),
+  hasMore: z.boolean(),
+  nextOffset: z.number().int().nonnegative().nullable(),
+  diff: z.string(),
+};
+
+const testStatusOutputSchema = {
+  available: z.boolean(),
+  message: z.string().optional(),
+  taskId: z.string().optional(),
+  iteration: z.number().int().optional(),
+  tests: z.string().nullable().optional(),
+  exitStatus: z.string().optional(),
+  timestamp: z.string().optional(),
+  outputAvailable: z.boolean().optional(),
+  outputId: z.number().int().positive().nullable().optional(),
+};
+
+const executionRecordOutputSchema = z.object({
+  taskId: z.string(),
+  iteration: z.number().int(),
+  changedFiles: z.union([z.array(z.string()), z.number().int().nonnegative()]),
+  tests: z.string().nullable(),
+  exitStatus: z.string(),
+  timestamp: z.string(),
+  notes: z.string().optional(),
+  outputId: z.number().int().positive().optional(),
+  outputAvailable: z.boolean().optional(),
+});
+
+const executionSummaryOutputSchema = {
+  records: z.array(executionRecordOutputSchema),
+};
+
+const executionOutputItemOutputSchema = z.object({
+  id: z.number().int().positive(),
+  command: z.string(),
+  exitCode: z.number().int().nullable(),
+  timestamp: z.string(),
+  taskId: z.string().nullable(),
+  iteration: z.number().int().nullable(),
+  readable: z.boolean(),
+  status: z.enum(["readable", "restricted"]),
+  truncated: z.boolean(),
+  sizeBytes: z.number().int().nonnegative(),
+});
+
+const executionOutputOutputSchema = {
+  action: z.enum(["list", "read"]).describe("The operation represented by this result"),
+  items: z.array(executionOutputItemOutputSchema).optional().describe("Recorded output metadata returned by the list operation"),
+  id: z.number().int().positive().optional(),
+  command: z.string().optional(),
+  exitCode: z.number().int().nullable().optional(),
+  timestamp: z.string().optional(),
+  truncated: z.boolean().optional(),
+  text: z.string().optional().describe("Sanitized command output returned by the read operation"),
+};
+
 export interface McpContext {
   workspace: Workspace;
   logger: Logger;
@@ -68,6 +207,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `Get an overview of the connected workspace: identity, project type, languages, ` +
         `frameworks, git state and available scripts. Call this first. ${UNTRUSTED_NOTE}`,
       inputSchema: {},
+      outputSchema: workspaceInfoOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (_args, extra) => {
@@ -76,7 +216,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       try {
         const project = workspace.detectProject();
         const git = gitInfo(workspace.root);
-        return ok({
+        return okStructured({
           workspaceId: workspace.id,
           workspaceName: workspace.name,
           rootAlias: "workspace:/",
@@ -107,13 +247,14 @@ export function createMcpServer(ctx: McpContext): McpServer {
         limit: z.number().int().min(1).max(1000).default(200),
         offset: z.number().int().min(0).default(0),
       },
+      outputSchema: listDirectoryOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
       const denied = requireScope(extra.authInfo, "workspace.read");
       if (denied) return denied;
       try {
-        return ok(await workspace.listDirectory(args.path, args));
+        return okStructured(await workspace.listDirectory(args.path, args));
       } catch (error) {
         return mapError(error);
       }
@@ -133,13 +274,14 @@ export function createMcpServer(ctx: McpContext): McpServer {
         start_line: z.number().int().min(1).optional().describe("1-based first line to return"),
         end_line: z.number().int().min(1).optional().describe("1-based last line to return"),
       },
+      outputSchema: readFileOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
       const denied = requireScope(extra.authInfo, "workspace.read");
       if (denied) return denied;
       try {
-        return ok(await workspace.readFile(args.path, { startLine: args.start_line, endLine: args.end_line }));
+        return okStructured(await workspace.readFile(args.path, { startLine: args.start_line, endLine: args.end_line }));
       } catch (error) {
         return mapError(error);
       }
@@ -160,13 +302,14 @@ export function createMcpServer(ctx: McpContext): McpServer {
         limit: z.number().int().min(1).max(200).default(50),
         regex: z.boolean().default(false).describe("Treat query as a regular expression"),
       },
+      outputSchema: searchWorkspaceOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
       const denied = requireScope(extra.authInfo, "workspace.search");
       if (denied) return denied;
       try {
-        return ok(await searchWorkspace(workspace, args));
+        return okStructured(await searchWorkspace(workspace, args));
       } catch (error) {
         return mapError(error);
       }
@@ -179,13 +322,14 @@ export function createMcpServer(ctx: McpContext): McpServer {
       title: "Git status",
       description: `Structured git status of the workspace: branch, staged/unstaged/untracked files. ${UNTRUSTED_NOTE}`,
       inputSchema: {},
+      outputSchema: gitStatusOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (_args, extra) => {
       const denied = requireScope(extra.authInfo, "git.read");
       if (denied) return denied;
       try {
-        return ok(gitStatus(workspace.root));
+        return okStructured(gitStatus(workspace.root));
       } catch (error) {
         return mapError(error);
       }
@@ -205,6 +349,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         offset: z.number().int().min(0).default(0).describe("Byte offset for pagination"),
         max_bytes: z.number().int().min(1024).max(262144).default(65536),
       },
+      outputSchema: gitDiffOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
@@ -215,7 +360,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         if (args.path) {
           relPath = workspace.resolve(args.path).rel;
         }
-        return ok(
+        return okStructured(
           gitDiff(
             workspace,
             { mode: args.mode as DiffMode, offset: args.offset, maxBytes: args.max_bytes },
@@ -236,6 +381,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `Summary of the most recent test run reported by the Codex harness. This does NOT run ` +
         `tests; it reads the latest execution record. ${UNTRUSTED_NOTE}`,
       inputSchema: {},
+      outputSchema: testStatusOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (_args, extra) => {
@@ -243,9 +389,9 @@ export function createMcpServer(ctx: McpContext): McpServer {
       if (denied) return denied;
       const latest = latestExecutionRecord(workspace.id);
       if (!latest) {
-        return ok({ available: false, message: "No execution records yet for this workspace." });
+        return okStructured({ available: false, message: "No execution records yet for this workspace." });
       }
-      return ok({
+      return okStructured({
         available: true,
         taskId: latest.taskId,
         iteration: latest.iteration,
@@ -268,12 +414,13 @@ export function createMcpServer(ctx: McpContext): McpServer {
       inputSchema: {
         limit: z.number().int().min(1).max(50).default(5),
       },
+      outputSchema: executionSummaryOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {
       const denied = requireScope(extra.authInfo, "execution.read");
       if (denied) return denied;
-      return ok({ records: readExecutionRecords(workspace.id, args.limit) });
+      return okStructured({ records: readExecutionRecords(workspace.id, args.limit) });
     }
   );
 
@@ -290,32 +437,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         id: z.number().int().positive().optional(),
         limit: z.number().int().min(1).max(50).default(20),
       },
-      outputSchema: {
-        action: z.enum(["list", "read"]).describe("The operation represented by this result"),
-        items: z
-          .array(
-            z.object({
-              id: z.number().int().positive(),
-              command: z.string(),
-              exitCode: z.number().int().nullable(),
-              timestamp: z.string(),
-              taskId: z.string().nullable(),
-              iteration: z.number().int().nullable(),
-              readable: z.boolean(),
-              status: z.enum(["readable", "restricted"]),
-              truncated: z.boolean(),
-              sizeBytes: z.number().int().nonnegative(),
-            })
-          )
-          .optional()
-          .describe("Recorded output metadata returned by the list operation"),
-        id: z.number().int().positive().optional(),
-        command: z.string().optional(),
-        exitCode: z.number().int().nullable().optional(),
-        timestamp: z.string().optional(),
-        truncated: z.boolean().optional(),
-        text: z.string().optional().describe("Sanitized command output returned by the read operation"),
-      },
+      outputSchema: executionOutputOutputSchema,
       annotations: { readOnlyHint: true },
     },
     async (args, extra) => {

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -74,6 +74,17 @@ describe("MCP tools over Streamable HTTP", () => {
     for (const forbidden of ["write_file", "delete_file", "execute_shell", "git_commit", "install_package"]) {
       expect(names).not.toContain(forbidden);
     }
+
+    const executionOutput = tools.find((tool) => tool.name === "execution_output");
+    expect(executionOutput?.outputSchema).toMatchObject({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+        items: { type: "array" },
+        text: { type: "string" },
+      },
+      required: ["action"],
+    });
   });
 
   it("workspace_info returns identity and project detection", async () => {
@@ -188,16 +199,27 @@ describe("MCP tools over Streamable HTTP", () => {
       raw: "-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----",
       exitCode: 0,
     });
-    const list = jsonOf<{ items: { id: number; status: string; command: string; text?: string }[] }>(
-      await client.callTool({ name: "execution_output", arguments: { action: "list" } })
-    );
+    const listResult = await client.callTool({
+      name: "execution_output",
+      arguments: { action: "list" },
+    });
+    const list = jsonOf<{
+      action: "list";
+      items: { id: number; status: string; command: string; text?: string }[];
+    }>(listResult);
+    expect(listResult.structuredContent).toEqual(list);
+    expect(list.action).toBe("list");
     expect(list.items.some((item) => item.id === readable.id && item.status === "readable")).toBe(true);
     expect(list.items.some((item) => item.id === hidden.id && item.status === "restricted")).toBe(true);
     expect(list.items.every((item) => item.text === undefined)).toBe(true);
 
-    const body = jsonOf<{ text: string }>(
-      await client.callTool({ name: "execution_output", arguments: { action: "read", id: readable.id } })
-    );
+    const readResult = await client.callTool({
+      name: "execution_output",
+      arguments: { action: "read", id: readable.id },
+    });
+    const body = jsonOf<{ action: "read"; text: string }>(readResult);
+    expect(readResult.structuredContent).toEqual(body);
+    expect(body.action).toBe("read");
     expect(body.text).toContain("AssertionError");
 
     const denied = await client.callTool({

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -21,6 +21,24 @@ function jsonOf<T = Record<string, unknown>>(result: { content?: unknown }): T {
   return JSON.parse(textOf(result)) as T;
 }
 
+function structuredJsonOf<T = Record<string, unknown>>(result: { content?: unknown; structuredContent?: unknown }): T {
+  const parsed = jsonOf<T>(result);
+  expect(result.structuredContent).toEqual(parsed);
+  return parsed;
+}
+
+function expectToolOutputSchema(
+  tools: Awaited<ReturnType<Client["listTools"]>>["tools"],
+  name: string,
+  properties: string[]
+): void {
+  const schema = tools.find((tool) => tool.name === name)?.outputSchema as
+    | { type?: string; properties?: Record<string, unknown> }
+    | undefined;
+  expect(schema?.type).toBe("object");
+  expect(Object.keys(schema?.properties ?? {})).toEqual(expect.arrayContaining(properties));
+}
+
 beforeAll(async () => {
   isolateStateDir();
   root = makeTmpDir("mcp-ws");
@@ -75,21 +93,20 @@ describe("MCP tools over Streamable HTTP", () => {
       expect(names).not.toContain(forbidden);
     }
 
-    const executionOutput = tools.find((tool) => tool.name === "execution_output");
-    expect(executionOutput?.outputSchema).toMatchObject({
-      type: "object",
-      properties: {
-        action: { type: "string" },
-        items: { type: "array" },
-        text: { type: "string" },
-      },
-      required: ["action"],
-    });
+    expectToolOutputSchema(tools, "workspace_info", ["workspaceId", "workspaceName", "projectType", "git"]);
+    expectToolOutputSchema(tools, "list_directory", ["path", "entries", "total", "hasMore"]);
+    expectToolOutputSchema(tools, "read_file", ["path", "content", "startLine", "endLine", "nextStartLine"]);
+    expectToolOutputSchema(tools, "search_workspace", ["matches", "matchCount", "truncated", "engine"]);
+    expectToolOutputSchema(tools, "git_status", ["isRepo", "branch", "staged", "unstaged", "untracked"]);
+    expectToolOutputSchema(tools, "git_diff", ["isRepo", "mode", "diff", "hasMore", "nextOffset"]);
+    expectToolOutputSchema(tools, "test_status", ["available", "tests", "outputAvailable", "outputId"]);
+    expectToolOutputSchema(tools, "execution_summary", ["records"]);
+    expectToolOutputSchema(tools, "execution_output", ["action", "items", "text"]);
   });
 
   it("workspace_info returns identity and project detection", async () => {
     const result = await client.callTool({ name: "workspace_info", arguments: {} });
-    const info = jsonOf<{ workspaceId: string; projectType: string; frameworks: string[]; git: { isRepo: boolean; branch: string } }>(result);
+    const info = structuredJsonOf<{ workspaceId: string; projectType: string; frameworks: string[]; git: { isRepo: boolean; branch: string } }>(result);
     expect(info.workspaceId).toBe(bridge.workspace.id);
     expect(info.projectType).toBe("node");
     expect(info.frameworks).toContain("React");
@@ -99,7 +116,7 @@ describe("MCP tools over Streamable HTTP", () => {
 
   it("read_file returns hello.txt", async () => {
     const result = await client.callTool({ name: "read_file", arguments: { path: "hello.txt" } });
-    const file = jsonOf<{ content: string; totalLines: number }>(result);
+    const file = structuredJsonOf<{ content: string; totalLines: number }>(result);
     expect(file.content).toContain("Hello from Codex with ChatGPT!");
   });
 
@@ -118,7 +135,7 @@ describe("MCP tools over Streamable HTTP", () => {
 
   it("list_directory lists the tree", async () => {
     const result = await client.callTool({ name: "list_directory", arguments: { path: ".", depth: 2 } });
-    const listing = jsonOf<{ entries: { path: string }[] }>(result);
+    const listing = structuredJsonOf<{ entries: { path: string }[] }>(result);
     const paths = listing.entries.map((entry) => entry.path);
     expect(paths).toContain("hello.txt");
     expect(paths).toContain("src/index.ts");
@@ -127,20 +144,20 @@ describe("MCP tools over Streamable HTTP", () => {
 
   it("search_workspace finds matches", async () => {
     const result = await client.callTool({ name: "search_workspace", arguments: { query: "answer" } });
-    const search = jsonOf<{ matches: { path: string; line: number }[] }>(result);
+    const search = structuredJsonOf<{ matches: { path: string; line: number }[] }>(result);
     expect(search.matches.some((match) => match.path === "src/index.ts")).toBe(true);
   });
 
   it("git_status reports the dirty file", async () => {
     const result = await client.callTool({ name: "git_status", arguments: {} });
-    const status = jsonOf<{ isRepo: boolean; unstaged: { path: string }[] }>(result);
+    const status = structuredJsonOf<{ isRepo: boolean; unstaged: { path: string }[] }>(result);
     expect(status.isRepo).toBe(true);
     expect(status.unstaged.some((entry) => entry.path === "src/index.ts")).toBe(true);
   });
 
   it("git_diff shows the change", async () => {
     const result = await client.callTool({ name: "git_diff", arguments: { mode: "unstaged" } });
-    const diff = jsonOf<{ diff: string; hasMore: boolean }>(result);
+    const diff = structuredJsonOf<{ diff: string; hasMore: boolean }>(result);
     expect(diff.diff).toContain("answer = 43");
     expect(diff.hasMore).toBe(false);
   });
@@ -149,12 +166,12 @@ describe("MCP tools over Streamable HTTP", () => {
     const big = Array.from({ length: 20000 }, (_, i) => `content line ${i}`).join("\n");
     write(root, "big-change.txt", big);
     git(root, "add", "big-change.txt");
-    const first = jsonOf<{ hasMore: boolean; nextOffset: number; totalBytes: number; returnedBytes: number }>(
+    const first = structuredJsonOf<{ hasMore: boolean; nextOffset: number; totalBytes: number; returnedBytes: number }>(
       await client.callTool({ name: "git_diff", arguments: { mode: "staged", max_bytes: 4096 } })
     );
     expect(first.hasMore).toBe(true);
     expect(first.returnedBytes).toBeLessThanOrEqual(4096);
-    const second = jsonOf<{ offset: number; diff: string }>(
+    const second = structuredJsonOf<{ offset: number; diff: string }>(
       await client.callTool({
         name: "git_diff",
         arguments: { mode: "staged", max_bytes: 4096, offset: first.nextOffset },
@@ -174,12 +191,12 @@ describe("MCP tools over Streamable HTTP", () => {
       exitStatus: "ok",
       timestamp: new Date().toISOString(),
     });
-    const summary = jsonOf<{ records: { taskId: string }[] }>(
+    const summary = structuredJsonOf<{ records: { taskId: string }[] }>(
       await client.callTool({ name: "execution_summary", arguments: {} })
     );
     expect(summary.records[0].taskId).toBe("c2c_test1");
 
-    const status = jsonOf<{ available: boolean; tests: string; outputAvailable: boolean; outputId: number | null }>(
+    const status = structuredJsonOf<{ available: boolean; tests: string; outputAvailable: boolean; outputId: number | null }>(
       await client.callTool({ name: "test_status", arguments: {} })
     );
     expect(status.available).toBe(true);
@@ -203,11 +220,10 @@ describe("MCP tools over Streamable HTTP", () => {
       name: "execution_output",
       arguments: { action: "list" },
     });
-    const list = jsonOf<{
+    const list = structuredJsonOf<{
       action: "list";
       items: { id: number; status: string; command: string; text?: string }[];
     }>(listResult);
-    expect(listResult.structuredContent).toEqual(list);
     expect(list.action).toBe("list");
     expect(list.items.some((item) => item.id === readable.id && item.status === "readable")).toBe(true);
     expect(list.items.some((item) => item.id === hidden.id && item.status === "restricted")).toBe(true);
@@ -217,8 +233,7 @@ describe("MCP tools over Streamable HTTP", () => {
       name: "execution_output",
       arguments: { action: "read", id: readable.id },
     });
-    const body = jsonOf<{ action: "read"; text: string }>(readResult);
-    expect(readResult.structuredContent).toEqual(body);
+    const body = structuredJsonOf<{ action: "read"; text: string }>(readResult);
     expect(body.action).toBe("read");
     expect(body.text).toContain("AssertionError");
 

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -108,7 +108,7 @@ describe("CloudflaredQuickTunnel", () => {
     expect(spawnImpl).toHaveBeenCalledWith(
       "cloudflared",
       ["tunnel", "--url", "http://127.0.0.1:3333", "--no-autoupdate"],
-      { stdio: ["ignore", "pipe", "pipe"] }
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
     );
     expect(fetchImpl).toHaveBeenCalledWith(`${QUICK_URL}/health`, {
       redirect: "error",


### PR DESCRIPTION
## Summary

- advertise MCP output schemas for all read-only tools, including workspace, file, search, git, test, execution summary, and execution output results
- return matching structuredContent while retaining existing text JSON content
- cover every advertised output schema and structured successful result in integration tests
- update the stale quick-tunnel spawn expectation for windowsHide: true introduced by 0b70588

## Testing

- corepack pnpm typecheck
- corepack pnpm build
- corepack pnpm test (154 tests)
- git diff --check
