### PR TITLE
Harden structured MCP outputs after #238

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -67,6 +67,34 @@ const cross = (msg: string): void => say(`✗ ${msg}`);
 
 function resolveWorkspace(option?: string): string {
   return path.resolve(option ?? process.cwd());
+}
+
+function parseInteger(value: string): number {
+  const normalized = value.trim();
+  if (!/^-?\d+$/.test(normalized)) {
+    throw new InvalidArgumentError("must be an integer");
+  }
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed)) throw new InvalidArgumentError("must be a safe integer");
+  return parsed;
+}
+
+function parseNonNegativeInteger(value: string): number {
+  const parsed = parseInteger(value);
+  if (parsed < 0) throw new InvalidArgumentError("must be a non-negative integer");
+  return parsed;
+}
+
+function parseChangedFiles(value: string): string[] | number {
+  const normalized = value.trim();
+  if (/^-?\d+$/.test(normalized)) {
+    const count = parseInteger(normalized);
+    if (count < 0) {
+      throw new InvalidArgumentError("changed-files count must be a non-negative safe integer");
+    }
+    return count;
+  }
+  return value.split(",").map((file) => file.trim()).filter(Boolean);
 }
 
 /** Local harness output only. Never pasted into ChatGPT. */
@@ -1024,7 +1052,7 @@ program
   .description("Record a Codex execution summary (used by the Skill)")
   .option("-w, --workspace <path>")
   .requiredOption("--task <id>")
-  .requiredOption("--iteration <n>")
+  .requiredOption("--iteration <n>", "non-negative execution iteration", parseNonNegativeInteger)
   .option("--changed-files <filesOrCount>", "comma-separated files or a count", "0")
   .option("--tests <summary>", "e.g. '27 passed'")
   .option("--exit-status <status>", "ok | failed | blocked", "ok")
@@ -1032,12 +1060,12 @@ program
   .option("--command <text>", "command whose output may be offered to ChatGPT")
   .option("--output <text>", "command output (prefer --output-file for long logs)")
   .option("--output-file <path>", "read command output from a local file")
-  .option("--exit-code <n>", "numeric exit code of that command")
+  .option("--exit-code <n>", "numeric exit code of that command", parseInteger)
   .action(
     (opts: {
       workspace?: string;
       task: string;
-      iteration: string;
+      iteration: number;
       changedFiles: string;
       tests?: string;
       exitStatus: string;
@@ -1045,12 +1073,10 @@ program
       command?: string;
       output?: string;
       outputFile?: string;
-      exitCode?: string;
+      exitCode?: number;
     }) => {
       const workspace = new Workspace(resolveWorkspace(opts.workspace));
-      const changed = /^\d+$/.test(opts.changedFiles)
-        ? parseInt(opts.changedFiles, 10)
-        : opts.changedFiles.split(",").map((file) => file.trim()).filter(Boolean);
+      const changed = parseChangedFiles(opts.changedFiles);
       let outputId: number | undefined;
       let outputAvailable = false;
       const rawOutput =
@@ -1061,16 +1087,16 @@ program
         const savedOutput = saveExecutionOutput(workspace.id, {
           command: opts.command,
           raw: rawOutput,
-          exitCode: opts.exitCode !== undefined ? parseInt(opts.exitCode, 10) : null,
+          exitCode: opts.exitCode ?? null,
           taskId: opts.task,
-          iteration: parseInt(opts.iteration, 10),
+          iteration: opts.iteration,
         });
         outputId = savedOutput.id;
         outputAvailable = savedOutput.allowed;
       }
       appendExecutionRecord(workspace.id, {
         taskId: opts.task,
-        iteration: parseInt(opts.iteration, 10),
+        iteration: opts.iteration,
         changedFiles: changed,
         tests: opts.tests ?? null,
         exitStatus: opts.exitStatus,

--- a/src/execution/records.ts
+++ b/src/execution/records.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import { ensureDir, getStateDir } from "../config/paths.js";
 
 /**
@@ -7,18 +8,19 @@ import { ensureDir, getStateDir } from "../config/paths.js";
  * iteration (via `c2c record`). ChatGPT reads them through the
  * `execution_summary` and `test_status` MCP tools.
  */
-export interface ExecutionRecord {
-  taskId: string;
-  iteration: number;
-  changedFiles: string[] | number;
-  tests: string | null;
-  exitStatus: "ok" | "failed" | "blocked" | string;
-  timestamp: string;
-  notes?: string;
-  /** Present when Codex recorded a sanitized command output for this iteration. */
-  outputId?: number;
-  outputAvailable?: boolean;
-}
+export const executionRecordSchema = z.object({
+  taskId: z.string(),
+  iteration: z.number().int().nonnegative(),
+  changedFiles: z.union([z.array(z.string()), z.number().int().nonnegative()]),
+  tests: z.string().nullable(),
+  exitStatus: z.string(),
+  timestamp: z.string(),
+  notes: z.string().optional(),
+  outputId: z.number().int().positive().optional(),
+  outputAvailable: z.boolean().optional(),
+});
+
+export type ExecutionRecord = z.infer<typeof executionRecordSchema>;
 
 function recordsFile(workspaceId: string): string {
   const dir = ensureDir(path.join(getStateDir(), "executions"));
@@ -27,7 +29,7 @@ function recordsFile(workspaceId: string): string {
 
 export function appendExecutionRecord(workspaceId: string, record: ExecutionRecord): void {
   const file = recordsFile(workspaceId);
-  fs.appendFileSync(file, JSON.stringify(record) + "\n", { mode: 0o600 });
+  fs.appendFileSync(file, JSON.stringify(executionRecordSchema.parse(record)) + "\n", { mode: 0o600 });
 }
 
 export function readExecutionRecords(workspaceId: string, limit = 10): ExecutionRecord[] {
@@ -35,14 +37,16 @@ export function readExecutionRecords(workspaceId: string, limit = 10): Execution
   if (!fs.existsSync(file)) return [];
   const lines = fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean);
   const records: ExecutionRecord[] = [];
-  for (const line of lines.slice(-limit)) {
+  const requestedLimit = Math.max(1, Math.floor(limit));
+  for (let index = lines.length - 1; index >= 0 && records.length < requestedLimit; index--) {
     try {
-      records.push(JSON.parse(line) as ExecutionRecord);
+      const record = executionRecordSchema.safeParse(JSON.parse(lines[index]));
+      if (record.success) records.push(record.data);
     } catch {
       // skip corrupt lines
     }
   }
-  return records;
+  return records.reverse();
 }
 
 export function latestExecutionRecord(workspaceId: string): ExecutionRecord | null {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,7 +4,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { Workspace, WorkspaceError } from "../workspace/manager.js";
 import { searchWorkspace } from "../workspace/search.js";
 import { gitDiff, gitInfo, gitStatus, type DiffMode } from "../workspace/git.js";
-import { latestExecutionRecord, readExecutionRecords } from "../execution/records.js";
+import { executionRecordSchema, latestExecutionRecord, readExecutionRecords } from "../execution/records.js";
 import { listExecutionOutputs, readExecutionOutput } from "../execution/output.js";
 import type { Logger } from "../logger/index.js";
 import { PRODUCT_NAME, VERSION } from "../version.js";
@@ -139,7 +139,7 @@ const testStatusOutputSchema = {
   available: z.boolean(),
   message: z.string().optional(),
   taskId: z.string().optional(),
-  iteration: z.number().int().optional(),
+  iteration: z.number().int().nonnegative().optional(),
   tests: z.string().nullable().optional(),
   exitStatus: z.string().optional(),
   timestamp: z.string().optional(),
@@ -147,20 +147,8 @@ const testStatusOutputSchema = {
   outputId: z.number().int().positive().nullable().optional(),
 };
 
-const executionRecordOutputSchema = z.object({
-  taskId: z.string(),
-  iteration: z.number().int(),
-  changedFiles: z.union([z.array(z.string()), z.number().int().nonnegative()]),
-  tests: z.string().nullable(),
-  exitStatus: z.string(),
-  timestamp: z.string(),
-  notes: z.string().optional(),
-  outputId: z.number().int().positive().optional(),
-  outputAvailable: z.boolean().optional(),
-});
-
 const executionSummaryOutputSchema = {
-  records: z.array(executionRecordOutputSchema),
+  records: z.array(executionRecordSchema),
 };
 
 const executionOutputItemOutputSchema = z.object({
@@ -342,7 +330,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       title: "Git diff",
       description:
         `Git diff with byte-offset pagination. mode: 'unstaged' (default), 'staged', or 'head' ` +
-        `(working tree vs HEAD). When has_more is true, call again with offset=next_offset. ${UNTRUSTED_NOTE}`,
+        `(working tree vs HEAD). When hasMore is true, call again with offset=nextOffset. ${UNTRUSTED_NOTE}`,
       inputSchema: {
         mode: z.enum(["unstaged", "staged", "head"]).default("unstaged"),
         path: z.string().optional().describe("Limit the diff to one workspace-relative path"),

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -60,6 +60,23 @@ export interface ProjectConfig {
   maxIterations?: number;
 }
 
+function parseProjectConfig(value: unknown): ProjectConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const raw = value as Record<string, unknown>;
+  const config: ProjectConfig = {};
+  if (typeof raw.name === "string") config.name = raw.name;
+  if (typeof raw.maxIterations === "number") config.maxIterations = raw.maxIterations;
+  return config;
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const entries = Object.entries(value as Record<string, unknown>).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  );
+  return Object.fromEntries(entries);
+}
+
 const DEFAULT_MAX_LINES = 400;
 const HARD_MAX_LINES = 2000;
 const DEFAULT_MAX_BYTES = 256 * 1024;
@@ -85,7 +102,7 @@ export class Workspace {
     this.root = real;
     this.id = createHash("sha256").update(normCase(real)).digest("hex").slice(0, 12);
     this.ignoreRules = new IgnoreRules(real);
-    this.projectConfig = readJsonIfExists<ProjectConfig>(path.join(real, ".c2c.json")) ?? {};
+    this.projectConfig = parseProjectConfig(readJsonIfExists<unknown>(path.join(real, ".c2c.json")));
     this.name = this.projectConfig.name ?? path.basename(real);
   }
 
@@ -308,13 +325,12 @@ export class Workspace {
     if (has("package.json")) {
       projectType = "node";
       languages.add("JavaScript");
-      const pkg = readJsonIfExists<{
-        scripts?: Record<string, string>;
-        dependencies?: Record<string, string>;
-        devDependencies?: Record<string, string>;
-      }>(path.join(this.root, "package.json"));
-      scripts = pkg?.scripts ?? {};
-      const deps = { ...(pkg?.dependencies ?? {}), ...(pkg?.devDependencies ?? {}) };
+      const rawPackage = readJsonIfExists<unknown>(path.join(this.root, "package.json"));
+      const pkg = rawPackage && typeof rawPackage === "object" && !Array.isArray(rawPackage)
+        ? rawPackage as Record<string, unknown>
+        : {};
+      scripts = stringRecord(pkg.scripts);
+      const deps = { ...stringRecord(pkg.dependencies), ...stringRecord(pkg.devDependencies) };
       const known: Record<string, string> = {
         next: "Next.js",
         react: "React",

--- a/tests/mcp-integration.test.ts
+++ b/tests/mcp-integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -11,6 +12,7 @@ let root: string;
 let bridge: Bridge;
 let client: Client;
 let accessToken: string;
+let stateDir: string;
 
 function textOf(result: { content?: unknown }): string {
   const content = result.content as { type: string; text: string }[];
@@ -40,7 +42,7 @@ function expectToolOutputSchema(
 }
 
 beforeAll(async () => {
-  isolateStateDir();
+  stateDir = isolateStateDir();
   root = makeTmpDir("mcp-ws");
   makeGitRepo(root);
   write(root, "package.json", JSON.stringify({ name: "demo", scripts: { test: "vitest run" }, dependencies: { react: "^19.0.0" } }));
@@ -102,6 +104,15 @@ describe("MCP tools over Streamable HTTP", () => {
     expectToolOutputSchema(tools, "test_status", ["available", "tests", "outputAvailable", "outputId"]);
     expectToolOutputSchema(tools, "execution_summary", ["records"]);
     expectToolOutputSchema(tools, "execution_output", ["action", "items", "text"]);
+  });
+
+  it("documents git_diff pagination with its output field names", async () => {
+    const { tools } = await client.listTools();
+    const description = tools.find((tool) => tool.name === "git_diff")?.description;
+    expect(description).toContain("hasMore");
+    expect(description).toContain("nextOffset");
+    expect(description).not.toContain("has_more");
+    expect(description).not.toContain("next_offset");
   });
 
   it("workspace_info returns identity and project detection", async () => {
@@ -203,6 +214,39 @@ describe("MCP tools over Streamable HTTP", () => {
     expect(status.tests).toBe("27 passed");
     expect(status.outputAvailable).toBe(false);
     expect(status.outputId).toBeNull();
+  });
+
+  it("skips invalid persisted records when reporting execution status", async () => {
+    appendExecutionRecord(bridge.workspace.id, {
+      taskId: "c2c_valid_before_invalid",
+      iteration: 2,
+      changedFiles: 0,
+      tests: "31 passed",
+      exitStatus: "ok",
+      timestamp: new Date().toISOString(),
+    });
+    fs.appendFileSync(
+      path.join(stateDir, "executions", `${bridge.workspace.id}.jsonl`),
+      JSON.stringify({
+        taskId: "c2c_invalid",
+        iteration: null,
+        changedFiles: 0,
+        tests: null,
+        exitStatus: "ok",
+        timestamp: new Date().toISOString(),
+      }) + "\n"
+    );
+
+    const statusResult = await client.callTool({ name: "test_status", arguments: {} });
+    expect(statusResult.isError ?? false).toBe(false);
+    const status = structuredJsonOf<{ taskId: string; iteration: number }>(statusResult);
+    expect(status.taskId).toBe("c2c_valid_before_invalid");
+    expect(status.iteration).toBe(2);
+
+    const summaryResult = await client.callTool({ name: "execution_summary", arguments: { limit: 1 } });
+    expect(summaryResult.isError ?? false).toBe(false);
+    const summary = structuredJsonOf<{ records: { taskId: string }[] }>(summaryResult);
+    expect(summary.records.map((record) => record.taskId)).toEqual(["c2c_valid_before_invalid"]);
   });
 
   it("execution_output lists readable items and refuses restricted bodies", async () => {

--- a/tests/record-cli.test.ts
+++ b/tests/record-cli.test.ts
@@ -1,0 +1,136 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { listExecutionOutputs } from "../src/execution/output.js";
+import { appendExecutionRecord, readExecutionRecords, type ExecutionRecord } from "../src/execution/records.js";
+import { Workspace } from "../src/workspace/manager.js";
+import { cleanup, makeTmpDir } from "./helpers.js";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const cliEntry = path.join(projectRoot, "src/cli/index.ts");
+
+function runRecord(root: string, args: string[]) {
+  return spawnSync(
+    process.execPath,
+    ["--import", "tsx", cliEntry, "record", "--workspace", root, "--task", "c2c_test", ...args],
+    { cwd: projectRoot, encoding: "utf8", env: process.env }
+  );
+}
+
+function withRecordEnvironment(run: (root: string, workspace: Workspace) => void): void {
+  const root = makeTmpDir("record-cli-workspace");
+  const stateDir = makeTmpDir("record-cli-state");
+  const previousStateDir = process.env.C2C_STATE_DIR;
+  process.env.C2C_STATE_DIR = stateDir;
+
+  try {
+    run(root, new Workspace(root));
+  } finally {
+    if (previousStateDir === undefined) delete process.env.C2C_STATE_DIR;
+    else process.env.C2C_STATE_DIR = previousStateDir;
+    cleanup(root);
+    cleanup(stateDir);
+  }
+}
+
+describe("c2c record", () => {
+  it("records valid numeric options and command output", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, [
+        "--iteration",
+        "2",
+        "--changed-files",
+        "3",
+        "--command",
+        "pnpm test",
+        "--output",
+        "tests passed",
+        "--exit-code",
+        "1",
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(readExecutionRecords(workspace.id)).toEqual([
+        expect.objectContaining({ taskId: "c2c_test", iteration: 2, changedFiles: 3 }),
+      ]);
+      expect(listExecutionOutputs(workspace.id)).toEqual([
+        expect.objectContaining({ command: "pnpm test", exitCode: 1, iteration: 2 }),
+      ]);
+    });
+  });
+
+  it("rejects a non-integer iteration without recording the execution", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, ["--iteration", "abc"]);
+
+      expect(result.status).toBe(1);
+      expect(readExecutionRecords(workspace.id)).toEqual([]);
+    });
+  });
+
+  it("rejects an unsafe changed-file count before recording command output", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, [
+        "--iteration",
+        "1",
+        "--changed-files",
+        "9".repeat(400),
+        "--command",
+        "pnpm test",
+        "--output",
+        "tests passed",
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(readExecutionRecords(workspace.id)).toEqual([]);
+      expect(listExecutionOutputs(workspace.id)).toEqual([]);
+    });
+  });
+
+  it("rejects a negative changed-file count", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, ["--iteration", "1", "--changed-files=-1"]);
+
+      expect(result.status).toBe(1);
+      expect(readExecutionRecords(workspace.id)).toEqual([]);
+    });
+  });
+
+  it("rejects a non-integer exit code before recording command output", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, [
+        "--iteration",
+        "1",
+        "--command",
+        "pnpm test",
+        "--output",
+        "tests passed",
+        "--exit-code",
+        "abc",
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(readExecutionRecords(workspace.id)).toEqual([]);
+      expect(listExecutionOutputs(workspace.id)).toEqual([]);
+    });
+  });
+});
+
+describe("execution record persistence", () => {
+  it("rejects invalid records at the write boundary", () => {
+    withRecordEnvironment((_root, workspace) => {
+      const invalidRecord: ExecutionRecord = {
+        taskId: "c2c_invalid",
+        iteration: Number.NaN,
+        changedFiles: 0,
+        tests: null,
+        exitStatus: "ok",
+        timestamp: new Date().toISOString(),
+      };
+
+      expect(() => appendExecutionRecord(workspace.id, invalidRecord)).toThrow();
+      expect(readExecutionRecords(workspace.id)).toEqual([]);
+    });
+  });
+});

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -188,4 +188,34 @@ describe("workspace identity", () => {
     expect(namedWs.projectConfig.maxIterations).toBe(12);
     cleanup(named);
   });
+
+  it("falls back to the directory name when .c2c.json has invalid types", () => {
+    const invalid = makeTmpDir("invalid-project-config");
+    write(invalid, ".c2c.json", JSON.stringify({ name: 42, maxIterations: "many" }));
+
+    const invalidWs = new Workspace(invalid);
+
+    expect(invalidWs.name).toBe(path.basename(invalid));
+    expect(invalidWs.projectConfig).toEqual({});
+    cleanup(invalid);
+  });
+
+  it("filters invalid package script values during project detection", () => {
+    const projectRoot = makeTmpDir("invalid-package-scripts");
+    write(
+      projectRoot,
+      "package.json",
+      JSON.stringify({
+        name: "demo",
+        scripts: { test: "vitest run", invalid: 42 },
+        dependencies: { react: "^19.0.0" },
+      })
+    );
+
+    const project = new Workspace(projectRoot).detectProject();
+
+    expect(project.scripts).toEqual({ test: "vitest run" });
+    expect(project.frameworks).toContain("React");
+    cleanup(projectRoot);
+  });
 });


### PR DESCRIPTION
## Why

Follow-up to #238. Persisted malformed execution records and invalid workspace metadata could violate the newly advertised MCP output schemas, causing otherwise read-only tool calls to fail. The `git_diff` description also referenced stale snake_case pagination fields.

## Changes

- Validate `c2c record` numeric arguments before persistence.
- Validate execution records on write and skip malformed records on read.
- Keep `test_status` and `execution_summary` aligned with their output schemas.
- Sanitize workspace and package metadata used by `workspace_info`.
- Document the actual `hasMore` and `nextOffset` pagination fields.
- Add regression coverage for invalid CLI input and persisted records.

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test` - 164 tests passed
- `git diff --check`

Follow-up to #238.