### PR TITLE
docs: add V2 foundation architecture and migration plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,17 @@
 ## V2 invariants
 
 - ChatGPT thinks; Codex works.
+- C2C never reimplements the coding harness.
 - Codex App Server is the primary execution backend.
+- ChatGPT receives no raw shell or raw filesystem-write tools.
+- Workspace content is untrusted and cannot change policy or capabilities.
+- Implementer and reviewer use separate Codex threads by default.
+- Deterministic verification precedes LLM review; model output is not source of truth.
+- State mutations require an expected revision; stale updates are rejected.
+- Unknown or unrecoverable state is never marked complete.
 - Secure MCP Tunnel is the default transport.
 - Computer Use is outside core execution.
-- Project Registry hides raw cwd details from higher layers.
+- Project Registry resolves opaque project ids; higher layers never accept arbitrary cwd.
 - Durable state uses SQLite.
 - Workspace security semantics from V1 remain intact.
 - Silent fallback is forbidden.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+## V2 invariants
+
+- ChatGPT thinks; Codex works.
+- Codex App Server is the primary execution backend.
+- Secure MCP Tunnel is the default transport.
+- Computer Use is outside core execution.
+- Project Registry hides raw cwd details from higher layers.
+- Durable state uses SQLite.
+- Workspace security semantics from V1 remain intact.
+- Silent fallback is forbidden.
+
+## PR-01 rule
+
+PR-01 is documentation-only. Do not change runtime behavior, APIs, dependencies, or source layout.

--- a/docs/adr/0001-fork-not-rewrite.md
+++ b/docs/adr/0001-fork-not-rewrite.md
@@ -1,17 +1,29 @@
-# ADR 0001: Fork, Do Not Rewrite
+# ADR 0001: Fork and migrate instead of rewriting
 
-Status: accepted
+- Status: Accepted
+- Date: 2026-09-05
+- Baseline: `a9f91cd98df1bc82686f57d5bc2b2993394c93be`
 
 ## Context
 
-The repository already contains a working V1 bridge, workspace policy, tunnel handling, and token storage model.
+V1 already has a working bridge and extensively tested workspace protections: canonical containment, symlink and traversal rejection, sensitive-file filtering, bounded reads/search/diffs, output sanitization, secure state permissions, and secret-redacting logs. A clean rewrite would discard those tested boundaries and combine product migration with security reimplementation.
 
 ## Decision
 
-V2 is a fork-and-migrate effort, not a clean rewrite.
+Build V2 as a fork of the named baseline and migrate behind explicit seams in small PRs. Keep main-equivalent behavior available until each replacement has parity, migration, and failure-path coverage. Delete legacy code only after its replacement is proven.
 
 ## Consequences
 
-- current security behavior stays the baseline
-- migration work can be split into small PRs
-- docs can describe future shape without implying current implementation
+- Existing workspace security behavior is the minimum acceptance bar.
+- Temporary duplication is acceptable when it makes rollback and comparison possible.
+- Each PR must state which path is authoritative and how to return to the prior path.
+- Source moves and cleanup happen after, not before, replacement verification.
+
+## Alternatives considered
+
+- **Clean rewrite:** rejected because it increases regression risk and delays usable checkpoints.
+- **Permanent V1 extension:** rejected because bridge, UI control, and file-state concerns need clearer boundaries.
+
+## PR-01 note
+
+This ADR changes no runtime behavior. The migration sequence is defined in [../migration-plan-v2.md](../migration-plan-v2.md).

--- a/docs/adr/0001-fork-not-rewrite.md
+++ b/docs/adr/0001-fork-not-rewrite.md
@@ -1,0 +1,17 @@
+# ADR 0001: Fork, Do Not Rewrite
+
+Status: accepted
+
+## Context
+
+The repository already contains a working V1 bridge, workspace policy, tunnel handling, and token storage model.
+
+## Decision
+
+V2 is a fork-and-migrate effort, not a clean rewrite.
+
+## Consequences
+
+- current security behavior stays the baseline
+- migration work can be split into small PRs
+- docs can describe future shape without implying current implementation

--- a/docs/adr/0002-app-server-primary.md
+++ b/docs/adr/0002-app-server-primary.md
@@ -1,0 +1,17 @@
+# ADR 0002: Codex App Server Is Primary
+
+Status: accepted
+
+## Context
+
+The current repository centers on a local bridge that exposes workspace services through MCP and tunnel plumbing.
+
+## Decision
+
+Codex App Server becomes the primary execution backend in V2.
+
+## Consequences
+
+- planning and review stay outside execution
+- the orchestrator does not become a second harness
+- execution semantics remain auditable and workspace-bound

--- a/docs/adr/0002-app-server-primary.md
+++ b/docs/adr/0002-app-server-primary.md
@@ -1,17 +1,32 @@
-# ADR 0002: Codex App Server Is Primary
+# ADR 0002: Use Codex App Server as the primary execution backend
 
-Status: accepted
+- Status: Accepted
+- Date: 2026-09-05
 
 ## Context
 
-The current repository centers on a local bridge that exposes workspace services through MCP and tunnel plumbing.
+C2C needs Codex-native thread, turn, event, diff, interrupt, and approval semantics. Implementing those semantics in the bridge would create another coding harness. OpenAI describes Codex App Server as the first-class integration method maintained for rich Codex integrations.
 
 ## Decision
 
-Codex App Server becomes the primary execution backend in V2.
+V2 executes coding work through Codex App Server. C2C adds a thin versioned adapter and supervisor; it does not reproduce the agent loop. App Server events are projected into C2C's durable domain state, and C2C's state is never inferred solely from model prose.
 
 ## Consequences
 
-- planning and review stay outside execution
-- the orchestrator does not become a second harness
-- execution semantics remain auditable and workspace-bound
+- Protocol/version compatibility becomes an explicit integration concern.
+- Startup, streaming, approval, interrupt, crash, and restart behavior require contract tests.
+- Unsupported versions fail before dispatch; there is no silent switch to another executor.
+- `codex mcp-server` may be evaluated for bounded compatibility cases but is not the primary V2 backend.
+
+## Alternatives considered
+
+- **Reimplement an agent loop:** rejected because C2C must not become a coding harness.
+- **Use only MCP server invocation:** not selected as primary because the required lifecycle is richer than a simple tool call.
+
+## Reference
+
+- OpenAI, [Unlocking the Codex harness: how we built the App Server](https://openai.com/index/unlocking-the-codex-harness/).
+
+## PR-01 note
+
+No App Server dependency or code is introduced in PR-01.

--- a/docs/adr/0003-secure-mcp-default.md
+++ b/docs/adr/0003-secure-mcp-default.md
@@ -1,0 +1,17 @@
+# ADR 0003: Secure MCP Tunnel by Default
+
+Status: accepted
+
+## Context
+
+The current implementation already treats public exposure as a tunnel-mediated path, with loopback-only bridge binding.
+
+## Decision
+
+Secure MCP Tunnel is the default transport for V2.
+
+## Consequences
+
+- public transport remains explicit
+- loopback-only local services stay private
+- compatibility transport paths, if any, stay outside core

--- a/docs/adr/0003-secure-mcp-default.md
+++ b/docs/adr/0003-secure-mcp-default.md
@@ -1,17 +1,32 @@
-# ADR 0003: Secure MCP Tunnel by Default
+# ADR 0003: Make Secure MCP Tunnel the default transport
 
-Status: accepted
+- Status: Accepted
+- Date: 2026-09-05
 
 ## Context
 
-The current implementation already treats public exposure as a tunnel-mediated path, with loopback-only bridge binding.
+V1 publishes a loopback bridge through Cloudflare and protects it with C2C-managed OAuth/pairing. OpenAI documents Secure MCP Tunnel for connecting private or developer-machine MCP servers to supported OpenAI products without exposing the server to the public internet. Availability can depend on the account and workspace.
 
 ## Decision
 
-Secure MCP Tunnel is the default transport for V2.
+V2 uses OpenAI Secure MCP Tunnel as its default transport and supervises the official client through a thin adapter. C2C does not implement the tunnel wire protocol. Cloudflare remains, if supported, only as an explicitly selected compatibility mode.
 
 ## Consequences
 
-- public transport remains explicit
-- loopback-only local services stay private
-- compatibility transport paths, if any, stay outside core
+- Capability/entitlement and client-version checks occur before startup.
+- Tunnel failures are typed and visible to the caller.
+- Failure or unavailability never triggers an automatic Cloudflare downgrade.
+- V1 loopback binding and authenticated access semantics remain required.
+
+## Alternatives considered
+
+- **Cloudflare remains default:** rejected for V2 because it retains public-endpoint and custom-auth operational complexity.
+- **Custom tunnel protocol:** rejected because C2C should not own a security-sensitive wire protocol.
+
+## Reference
+
+- OpenAI Help Center, [Developer mode and MCP apps in ChatGPT](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta).
+
+## PR-01 note
+
+PR-01 does not change the V1 Cloudflare default; it only records the V2 target.

--- a/docs/adr/0004-no-computer-use-core.md
+++ b/docs/adr/0004-no-computer-use-core.md
@@ -1,17 +1,28 @@
-# ADR 0004: Computer Use Stays Out of Core
+# ADR 0004: Keep Computer Use outside the core protocol
 
-Status: accepted
+- Status: Accepted
+- Date: 2026-09-05
 
 ## Context
 
-The current codebase keeps execution and transport logic in the local bridge and state files.
+V1 uses Computer Use for small control-plane messages between Codex and ChatGPT. UI automation couples correctness to page state and UI behavior, and it is difficult to reconcile deterministically after interruption. V2 needs an auditable server-shaped control plane.
 
 ## Decision
 
-Computer Use is not part of core execution in V2.
+Computer Use is not part of V2 core execution or orchestration. Core control uses high-level MCP task operations backed by durable activity state and Codex App Server events. A UI relay may exist only as an isolated, explicitly selected compatibility feature.
 
 ## Consequences
 
-- the core stays deterministic and server-shaped
-- control-plane actions remain separate from execution
-- no fallback path may quietly inject Computer Use into core behavior
+- Core state transitions no longer depend on browser observations.
+- Every mutation can be validated, revision-checked, persisted, and audited.
+- Compatibility UI failures cannot change core policy or completion state.
+- There is no silent injection of Computer Use when a control-plane capability is unavailable.
+
+## Alternatives considered
+
+- **Harden the UI protocol as core:** rejected because it cannot provide the same deterministic lifecycle boundary.
+- **Remove all compatibility support immediately:** rejected; fork migration requires staged parity and rollback.
+
+## PR-01 note
+
+The existing V1 Computer Use workflow remains unchanged in PR-01.

--- a/docs/adr/0004-no-computer-use-core.md
+++ b/docs/adr/0004-no-computer-use-core.md
@@ -1,0 +1,17 @@
+# ADR 0004: Computer Use Stays Out of Core
+
+Status: accepted
+
+## Context
+
+The current codebase keeps execution and transport logic in the local bridge and state files.
+
+## Decision
+
+Computer Use is not part of core execution in V2.
+
+## Consequences
+
+- the core stays deterministic and server-shaped
+- control-plane actions remain separate from execution
+- no fallback path may quietly inject Computer Use into core behavior

--- a/docs/adr/0005-project-registry.md
+++ b/docs/adr/0005-project-registry.md
@@ -1,17 +1,28 @@
-# ADR 0005: Project Registry Hides cwd
+# ADR 0005: Resolve workspaces through a Project Registry
 
-Status: accepted
+- Status: Accepted
+- Date: 2026-09-05
 
 ## Context
 
-Current workspace identity is derived from the local root and persisted state.
+An external model-supplied absolute cwd would expose host layout and turn project selection into an unsafe capability. V1 already has strong canonical workspace containment, but V2 needs durable mapping between orchestration state and local workspaces.
 
 ## Decision
 
-V2 introduces a Project Registry layer that owns workspace identity and hides raw cwd details from higher layers.
+Introduce a local Project Registry. Remote/control-plane requests provide an opaque `project_id`; the registry resolves it to a canonical local root and allowed profile. Registration and root changes occur only through a local privileged administration path. Higher layers never accept arbitrary cwd.
 
 ## Consequences
 
-- workspace mapping becomes explicit
-- raw local paths stop leaking into control logic
-- project selection can be reasoned about without depending on the caller's process cwd
+- Host paths are absent from normal external task requests and responses.
+- Unknown, moved, duplicated, or cross-project mappings fail explicitly.
+- Registry resolution reuses V1 realpath containment and security rules.
+- Project identity becomes stable input to activities, policies, evidence, and audit records.
+
+## Alternatives considered
+
+- **Accept cwd with validation:** rejected because it still exposes host paths and lets callers attempt project selection.
+- **Use process cwd implicitly:** rejected because it is ambiguous across daemon, restart, and multi-project operation.
+
+## PR-01 note
+
+No registry or workspace API is implemented in PR-01.

--- a/docs/adr/0005-project-registry.md
+++ b/docs/adr/0005-project-registry.md
@@ -1,0 +1,17 @@
+# ADR 0005: Project Registry Hides cwd
+
+Status: accepted
+
+## Context
+
+Current workspace identity is derived from the local root and persisted state.
+
+## Decision
+
+V2 introduces a Project Registry layer that owns workspace identity and hides raw cwd details from higher layers.
+
+## Consequences
+
+- workspace mapping becomes explicit
+- raw local paths stop leaking into control logic
+- project selection can be reasoned about without depending on the caller's process cwd

--- a/docs/adr/0006-sqlite-state.md
+++ b/docs/adr/0006-sqlite-state.md
@@ -1,17 +1,28 @@
-# ADR 0006: SQLite for Durable State
+# ADR 0006: Use SQLite for durable orchestration state
 
-Status: accepted
+- Status: Accepted
+- Date: 2026-09-05
 
 ## Context
 
-The current implementation stores runtime, auth, tunnel, and session state as JSON files in the user state directory.
+V1 stores runtime, endpoint, tunnel, auth, execution, and session information in separate files. V2 adds concurrent activities, revisions, approvals, evidence, reviews, idempotent operations, and crash recovery. These records need atomic multi-record transitions and queryable history.
 
 ## Decision
 
-V2 uses SQLite for durable state.
+Use SQLite as the source of truth for V2 Project, Activity, Agent, Job, Approval, Evidence, Review, Operation, and audit-event records. Access it through repository interfaces so the domain does not depend on a driver. Use versioned transactional migrations, WAL mode after validation, backup/restore tests, and the existing OS user-state location and permissions.
 
 ## Consequences
 
-- coordination state becomes transactional
-- workspace binding remains outside the project tree
-- file-based state can remain as legacy compatibility only if isolated from core
+- State transitions and revision increments can commit atomically.
+- Recovery can distinguish incomplete, stale, and terminal work.
+- Migration and schema compatibility become release-gated responsibilities.
+- Secrets remain in appropriate protected storage; SQLite adoption is not permission to centralize credentials in plaintext.
+
+## Alternatives considered
+
+- **Continue independent JSON/JSONL files:** rejected because cross-record atomicity and concurrency would be reimplemented poorly.
+- **External database service:** rejected for the local-first default because it adds deployment and trust dependencies.
+
+## PR-01 note
+
+PR-01 adds no database package, schema, or state migration.

--- a/docs/adr/0006-sqlite-state.md
+++ b/docs/adr/0006-sqlite-state.md
@@ -1,0 +1,17 @@
+# ADR 0006: SQLite for Durable State
+
+Status: accepted
+
+## Context
+
+The current implementation stores runtime, auth, tunnel, and session state as JSON files in the user state directory.
+
+## Decision
+
+V2 uses SQLite for durable state.
+
+## Consequences
+
+- coordination state becomes transactional
+- workspace binding remains outside the project tree
+- file-based state can remain as legacy compatibility only if isolated from core

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -1,59 +1,239 @@
 # codex-with-chatgpt 2.0 Architecture
 
-Baseline: `a9f91cd98df1bc82686f57d5bc2b2993394c93be`
+Status: target architecture; not implemented by PR-01  
+Baseline: `a9f91cd98df1bc82686f57d5bc2b2993394c93be` (`v0.1.2` tag, package version `0.1.1`)
 
-## 現状
+## 1. Purpose
 
-The current codebase is a single local bridge that composes:
+V2 preserves the product idea **“ChatGPT thinks. Codex works.”** while replacing the UI-driven control path with an explicit, durable orchestration boundary. ChatGPT plans, reviews, and makes the final judgment. Codex performs execution through Codex App Server. C2C coordinates the two; it does not reimplement the Codex harness.
 
-- workspace discovery and containment
-- OAuth / pairing / token storage
-- MCP read endpoints
-- tunnel provisioning
-- admin / daemon lifecycle
-- execution record persistence
+PR-01 records this contract only. Every component labeled “V2 target” below is future work.
 
-The implementation is intentionally conservative about workspace security:
+## 2. Baseline and target
 
-- the bridge binds to loopback only
-- public exposure goes through the tunnel
-- tokens are bound to a workspace
-- workspace content is treated as untrusted
-- state is stored under the user state directory, not the project
+### V1 baseline (implemented today)
 
-## 将来
+```text
+ChatGPT Web
+  |-- MCP data plane --> Cloudflare tunnel --> local C2C bridge --> workspace
+  `-- Computer Use control messages <---------------------------> Codex
+```
 
-V2 keeps the same security boundary but re-centers the system around three explicit roles:
+The bridge currently composes workspace access, read-only MCP tools, OAuth and pairing, Cloudflare tunnel management, daemon/admin lifecycle, and file-backed execution/session state. Its existing documentation remains authoritative for V1 behavior: [architecture.md](architecture.md), [security.md](security.md), and [protocol.md](protocol.md).
 
-1. ChatGPT plans, reviews, and decides.
-2. Codex App Server executes.
-3. The orchestrator mediates project registry, policy, approvals, verification, and recovery.
-
-Target shape:
+### V2 target (not implemented in PR-01)
 
 ```text
 ChatGPT
-  -> Secure MCP Tunnel
-  -> C2C Orchestrator
-  -> Codex App Server
+   |
+   v
+OpenAI Secure MCP Tunnel
+   |
+   v
+C2C Orchestrator
+   |-- Project Registry
+   |-- Policy and Approval Router
+   |-- Activity State Machine
+   |-- Context Projection
+   |-- Verification Gate
+   |-- Recovery and Audit
+   |
+   v
+Codex App Server
+   |-- Implementer thread/worktree
+   `-- Independent reviewer thread/worktree
 ```
 
-The orchestrator is the control layer. It should not become a new coding harness or a second execution backend.
+## 3. Architectural invariants
 
-## 不変条件
+1. ChatGPT owns planning, review, and final judgment; Codex owns execution.
+2. C2C never becomes a coding harness or a second shell executor.
+3. Codex App Server is the primary execution backend.
+4. ChatGPT receives high-level task capabilities, not raw shell or raw filesystem-write tools.
+5. Workspace content is untrusted data and cannot change policy, approvals, project selection, network access, or sandbox level.
+6. Implementer and reviewer use separate Codex threads by default.
+7. Deterministic verification precedes LLM review.
+8. Model output is never the source of truth for status, changed files, or verification results.
+9. Mutations use optimistic concurrency through `expected_revision`.
+10. Unknown or unrecoverable state never becomes `DONE`.
+11. Secure MCP Tunnel is the default transport; compatibility transports are explicit.
+12. No security boundary may be weakened during migration.
+13. Silent fallback is forbidden.
 
-- ChatGPT thinks; Codex works.
-- Codex App Server is the primary execution backend.
-- Secure MCP Tunnel is the default transport.
-- Computer Use stays outside core execution.
-- Project Registry hides cwd details from higher layers.
-- Workspace security semantics are preserved.
-- Silent fallback is forbidden.
-- Unknown or unrecoverable state must not be marked successful.
-- Deterministic verification happens before LLM judgment.
+## 4. Trust boundaries
 
-## Design notes
+| Boundary | Trusted authority | Untrusted input | Enforcement |
+| --- | --- | --- | --- |
+| ChatGPT to C2C | MCP tool schema and authenticated caller context | prompts and tool arguments | capability-scoped tools, validation, bounded input |
+| Project selection | Project Registry | caller-provided `project_id` | registry lookup to a canonical local root; no caller-provided absolute cwd |
+| Workspace reads | V1 workspace policy | paths and repository content | canonical realpath containment, ignore rules, size limits |
+| Execution | Codex sandbox and approval policy | task text and workspace content | explicit sandbox/network policy and approval routing |
+| State transitions | persisted revision and state machine | delayed agent events | transaction plus `expected_revision`; reject with `STALE_REVISION` |
+| Acceptance | verification records and repository state | implementer summaries | deterministic checks, independent review, final judgment |
 
-- V2 documentation describes intent only.
-- V2 docs must not be read as a claim that baseline behavior has already changed.
-- If a file is listed as part of V2 planning, that is a migration target, not a current code path.
+## 5. Component responsibilities
+
+### C2C Orchestrator
+
+The orchestrator owns coordination, not code execution. It creates activities, dispatches Codex jobs, projects App Server events into durable state, routes approval requests, schedules verification and review, and exposes bounded status views.
+
+### Codex App Server adapter
+
+The adapter is a thin integration layer around the maintained App Server protocol. It owns process supervision, protocol/version compatibility, request correlation, streaming event handling, interrupts, and approval responses. Generated protocol types should be used where available. Unsupported protocol versions fail explicitly.
+
+### Project Registry
+
+External callers select a registered `project_id`. The registry resolves it locally to a canonical root and allowed execution profile. Absolute paths are not accepted through the MCP control plane. Registration and administrative changes are local privileged operations.
+
+### Policy and Approval Router
+
+Policy determines allowed sandbox, network, secret, deployment, and external-side-effect capabilities. Approval decisions are explicit records tied to an activity, operation, revision, actor, and expiry. Repository text cannot create or widen an approval.
+
+### Verification Gate
+
+Verification runs project-configured deterministic checks before reviewer judgment. Initial candidates are `git diff --check`, typecheck, and tests. Evidence is collected from actual process results, not a model claim.
+
+### Independent Reviewer
+
+The reviewer receives the goal, success criteria, actual diff, relevant code, and verification evidence in a separate Codex thread. It returns structured findings and an outcome such as `ACCEPTED` or `FIX_REQUIRED`; it does not directly overwrite activity state.
+
+## 6. Domain model
+
+```text
+Project
+ `-- Activity
+      |-- Agent (Implementer)
+      |    `-- Job
+      |-- Agent (Reviewer)
+      |    `-- Job
+      |-- Approval
+      |-- Evidence
+      |-- Review
+      `-- Operation / Audit Event
+```
+
+- **Project**: registered local workspace identity and policy profile.
+- **Activity**: user-visible unit of work and authoritative lifecycle revision.
+- **Agent**: an execution or review role bound to a distinct Codex thread.
+- **Job**: one dispatch to an agent with protocol identifiers and timestamps.
+- **Approval**: a scoped decision for a proposed capability or action.
+- **Evidence**: immutable result of a deterministic check or inspected repository fact.
+- **Review**: structured independent assessment tied to evidence and a revision.
+- **Operation**: idempotency and audit record for externally requested mutations.
+
+## 7. Activity lifecycle and concurrency
+
+```text
+INTAKE -> PLANNING -> READY -> DISPATCHED -> EXECUTING
+                                             |
+                                             v
+                                         VERIFYING -> REVIEWING
+                                                        |-- FIX_REQUIRED -> EXECUTING
+                                                        `-- ACCEPTED -----> DONE
+
+Terminal: DONE | BLOCKED | CANCELLED | FAILED | RECOVERY_REQUIRED
+```
+
+Every mutation supplies `expected_revision`. In one SQLite transaction the service checks the current revision, validates the transition, writes state and audit event, and increments the revision. A mismatch returns `STALE_REVISION` with the current revision; it never retries an unsafe mutation implicitly.
+
+Cancellation and approval responses use idempotency keys. Duplicate requests return the recorded outcome. An App Server disconnect places work into a recoverable or `RECOVERY_REQUIRED` state until reconciliation proves the actual result.
+
+## 8. MCP boundary
+
+### Data plane
+
+The data plane remains read-only and preserves the V1 workspace policy:
+
+```text
+workspace_info
+list_directory
+read_file
+search_workspace
+git_status
+git_diff
+```
+
+Evidence/status readers may be added, but they expose sanitized persisted records rather than raw arbitrary files.
+
+### Control plane
+
+The target control surface is high-level delegation:
+
+```text
+c2c_task_start
+c2c_task_get
+c2c_task_continue
+c2c_task_steer
+c2c_task_cancel
+c2c_approval_respond
+```
+
+The control plane does not expose generic `shell`, `write_file`, unrestricted `git`, or caller-selected cwd parameters.
+
+## 9. Context projection
+
+Status reads support three bounded views:
+
+- `compact`: state, revision, current phase, and required user action.
+- `standard`: compact plus changed-file summary, verification status, and review outcome.
+- `debug`: bounded diagnostic events and sanitized output references.
+
+`since_revision` avoids replaying unchanged context. When nothing changed, the response is small and explicit, for example:
+
+```json
+{"status":"running","revision":31,"unchanged":true}
+```
+
+## 10. Durable state
+
+SQLite is the V2 source of truth for Project, Activity, Agent, Job, Approval, Evidence, Review, Operation, and audit-event records. Repositories isolate storage from the domain layer. Migrations are versioned and transactional; WAL mode and backup/recovery behavior are verified before legacy state is removed.
+
+Secrets remain in OS-appropriate protected storage. SQLite placement follows the existing user state-directory convention, outside project trees, with owner-only permissions where the platform supports them.
+
+## 11. Verification evidence
+
+Each check records at least:
+
+- check name and configured command
+- exit code and normalized status
+- start/end timestamps and duration
+- activity revision and repository revision
+- sanitized, bounded output reference
+
+Required-check failure prevents review acceptance. Review evidence must correspond to the same repository and activity revision being accepted.
+
+## 12. Transport and compatibility
+
+Secure MCP Tunnel is the default V2 transport because it connects a private/local MCP server without publishing that server directly to the public internet. C2C configures and supervises the official client through a thin adapter; it does not reimplement the tunnel wire protocol.
+
+Cloudflare transport, its OAuth/pairing path, and any Computer Use relay may remain only as explicitly selected compatibility modes. Missing Secure MCP entitlement, unsupported client versions, or startup failures are reported clearly. No automatic downgrade is allowed.
+
+## 13. V1 security semantics that must survive migration
+
+- canonical realpath containment and workspace-root authorization
+- rejection of `..`, absolute-path, null-byte, backslash, and symlink escapes
+- sensitive-file deny rules with `.env.example` exception
+- additive `.c2cignore` policy
+- secret exclusion from reads, listings, search, and every git-diff mode, including renames
+- bounded reads, searches, diffs, and outputs
+- private-key rejection and credential/home-path redaction in execution output
+- loopback-only local listeners and authenticated remote access
+- per-workspace identity and authorization boundaries
+- OS user-state placement with `0700` directories and `0600` files where supported
+- secret-redacting logs
+
+Security regression is a release blocker. Replacement code must have equivalent or stronger tests before the V1 path is removed.
+
+## 14. Failure and fallback policy
+
+- Unsupported App Server protocol: fail with a compatibility error.
+- Secure MCP Tunnel unavailable: report the prerequisite; require explicit compatibility-mode selection.
+- Unknown job after restart: reconcile from protocol and durable records or enter `RECOVERY_REQUIRED`.
+- Verification evidence missing/stale: do not review or mark `DONE`.
+- Stale mutation: return `STALE_REVISION`; do not silently replay it.
+
+## 15. References
+
+- OpenAI, [Unlocking the Codex harness: how we built the App Server](https://openai.com/index/unlocking-the-codex-harness/) (App Server as the first-class integration method).
+- OpenAI Help Center, [Developer mode and MCP apps in ChatGPT](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt-beta) (Secure MCP Tunnel for private/local MCP servers; availability is product/workspace dependent).
+- V1 repository documents: [architecture.md](architecture.md), [security.md](security.md), [protocol.md](protocol.md).

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -1,0 +1,59 @@
+# codex-with-chatgpt 2.0 Architecture
+
+Baseline: `a9f91cd98df1bc82686f57d5bc2b2993394c93be`
+
+## 現状
+
+The current codebase is a single local bridge that composes:
+
+- workspace discovery and containment
+- OAuth / pairing / token storage
+- MCP read endpoints
+- tunnel provisioning
+- admin / daemon lifecycle
+- execution record persistence
+
+The implementation is intentionally conservative about workspace security:
+
+- the bridge binds to loopback only
+- public exposure goes through the tunnel
+- tokens are bound to a workspace
+- workspace content is treated as untrusted
+- state is stored under the user state directory, not the project
+
+## 将来
+
+V2 keeps the same security boundary but re-centers the system around three explicit roles:
+
+1. ChatGPT plans, reviews, and decides.
+2. Codex App Server executes.
+3. The orchestrator mediates project registry, policy, approvals, verification, and recovery.
+
+Target shape:
+
+```text
+ChatGPT
+  -> Secure MCP Tunnel
+  -> C2C Orchestrator
+  -> Codex App Server
+```
+
+The orchestrator is the control layer. It should not become a new coding harness or a second execution backend.
+
+## 不変条件
+
+- ChatGPT thinks; Codex works.
+- Codex App Server is the primary execution backend.
+- Secure MCP Tunnel is the default transport.
+- Computer Use stays outside core execution.
+- Project Registry hides cwd details from higher layers.
+- Workspace security semantics are preserved.
+- Silent fallback is forbidden.
+- Unknown or unrecoverable state must not be marked successful.
+- Deterministic verification happens before LLM judgment.
+
+## Design notes
+
+- V2 documentation describes intent only.
+- V2 docs must not be read as a claim that baseline behavior has already changed.
+- If a file is listed as part of V2 planning, that is a migration target, not a current code path.

--- a/docs/migration-plan-v2.md
+++ b/docs/migration-plan-v2.md
@@ -1,62 +1,237 @@
 # codex-with-chatgpt 2.0 Migration Plan
 
+Status: planned sequence; only PR-01 is implemented  
 Baseline: `a9f91cd98df1bc82686f57d5bc2b2993394c93be`
 
-## Goal
+## 1. Migration rules
 
-Move from the current bridge-centered implementation to a Codex App Server-first architecture without changing baseline behavior in PR-01.
+- Keep main-equivalent behavior working until each replacement is complete and verified.
+- Preserve or strengthen every security semantic listed in [architecture-v2.md](architecture-v2.md).
+- Use one reviewable PR per step; do not bundle later steps into an earlier PR.
+- Run deterministic checks before independent review.
+- Remove legacy code only after its replacement passes migration and failure-injection tests.
+- Never silently fall back between execution backends, transports, policy profiles, or storage layers.
 
-## Scope of PR-01
+## 2. Source disposition summary
 
-This pull request is documentation-only:
+### Keep as security foundations
 
-- no runtime behavior changes
-- no API changes
-- no dependency changes
-- no file moves for source code
+`src/config/paths.ts`, `src/execution/sanitize.ts`, `src/mcp/http.ts`, `src/workspace/git.ts`, `src/workspace/ignore.ts`, and `src/workspace/search.ts` retain their responsibilities, subject only to narrowly scoped integration changes.
 
-## Planned epics
+### Modify or move during staged replacement
 
-### Epic 1: Architecture contract
+The current `auth/`, `bridge/`, `cli/`, `tunnel/`, `pairing/`, `process/`, `logger/`, `mcp/server.ts`, `workspace/manager.ts`, `execution/output.ts`, `config/endpoint.ts`, and `version.ts` modules contain reusable behavior but will move behind V2 boundaries or compatibility packages.
 
-- define the V2 architectural boundary
-- document what stays in core and what moves out
-- preserve current workspace security semantics
+### Delete only after replacement
 
-### Epic 2: Project Registry
+`src/config/sandbox-allow.ts`, `src/config/ui-prefs.ts`, `src/execution/records.ts`, and `src/session/state.ts` are legacy responsibilities. They must remain until their V2 replacements are live, migrated, and covered by tests.
 
-- derive workspace identity from registry metadata
-- avoid exposing raw cwd details to higher layers
-- keep workspace-to-execution mapping explicit
+## 3. Epic A — Foundation and seams
 
-### Epic 3: Durable state
+### PR-01: Fork baseline and architecture decisions (this PR)
 
-- move long-lived session and coordination state to SQLite
-- keep secrets and workspace binding outside the project tree
-- preserve owner-only permissions
+Issues:
 
-### Epic 4: Execution split
+- verify fork baseline is exactly `a9f91cd98df1bc82686f57d5bc2b2993394c93be`
+- record pre-change build, typecheck, and test results
+- add V2 architecture, this migration plan, six ADRs, and concise repository invariants
+- prove the diff changes no runtime, API, dependency, or test behavior
 
-- separate planning/review from execution
-- keep Codex App Server as the primary execution path
-- keep deterministic verification before review
+Exit criteria:
 
-### Epic 5: Transport and compatibility
+- build and typecheck pass
+- the complete baseline test suite passes
+- only `AGENTS.md` and the requested V2/ADR documents are changed
+- PR-02 work has not started
 
-- make Secure MCP Tunnel the default transport
-- keep any legacy compatibility paths isolated from core
-- forbid silent fallback between transports
+### PR-02: Split the CLI
 
-## Non-goals for PR-01
+Issues:
 
-- no code migration
-- no CLI changes
-- no auth/runtime refactor
-- no test expectation updates beyond verification runs
+- turn `src/cli/index.ts` into a thin bootstrap
+- extract command modules without changing flags, JSON output, or exit behavior
+- add CLI parity tests for existing commands
 
-## Acceptance bar
+Exit criteria: V1 command contract is unchanged and all existing tests pass.
 
-- baseline tests still pass
-- build and typecheck still pass
-- docs clearly distinguish current state from future state
-- no runtime diff is introduced
+### PR-03: Stabilize the TransportProvider seam
+
+Issues:
+
+- separate transport lifecycle from Cloudflare-specific provisioning
+- define explicit start/stop/status/doctor results and error taxonomy
+- remove implicit provider downgrade behavior
+
+Exit criteria: current Cloudflare modes pass parity tests through the provider interface; fallback decisions are explicit.
+
+### PR-04: Isolate Cloudflare and legacy auth
+
+Issues:
+
+- move Cloudflare provisioning, OAuth, pairing, and public-endpoint concerns under a compatibility boundary
+- remove core bridge dependencies on compatibility auth
+- retain V1 behavior behind an explicit compatibility configuration
+
+Exit criteria: compatibility E2E passes and core modules have no inward dependency on the compatibility package.
+
+## 4. Epic B — Official execution and transport integrations
+
+### PR-05: Add the Secure MCP Tunnel adapter
+
+Issues:
+
+- detect and validate official tunnel-client availability and entitlement prerequisites
+- implement configure/start/stop/status/doctor as a thin adapter
+- surface typed failures; require explicit opt-in for compatibility transport
+
+Exit criteria: local integration tests cover healthy, unavailable, incompatible, and interrupted tunnel states with no silent Cloudflare fallback.
+
+### PR-06: Introduce generated App Server protocol types
+
+Issues:
+
+- pin a tested Codex/App Server compatibility range
+- generate or vendor protocol types with provenance
+- add fixtures for initialization, thread, turn, item, approval, and error events
+
+Exit criteria: protocol fixtures validate in CI and unsupported versions fail before task dispatch.
+
+### PR-07: Build the App Server client and supervisor
+
+Issues:
+
+- implement process startup, JSON-RPC correlation, event streaming, interrupt, and shutdown
+- project protocol events into typed internal events
+- handle crash, disconnect, timeout, and restart without reporting false completion
+
+Exit criteria: lifecycle and failure-injection tests pass; Codex App Server is usable behind an internal backend interface.
+
+## 5. Epic C — Durable domain and project boundary
+
+### PR-08: Add SQLite and the domain model
+
+Issues:
+
+- define Project, Activity, Agent, Job, Approval, Evidence, Review, Operation, and audit-event records
+- add versioned transactional migrations and repository interfaces
+- configure user-state placement, owner-only permissions, WAL, backup, and recovery checks
+
+Exit criteria: migration/repository tests pass, partial transactions roll back, and secrets are not stored in project trees.
+
+### PR-09: Add Project Registry
+
+Issues:
+
+- register canonical workspace roots through a local privileged path
+- expose opaque `project_id` to higher layers instead of absolute cwd
+- reuse V1 realpath containment and workspace identity semantics
+
+Exit criteria: traversal, symlink, duplicate-root, moved-root, unknown-project, and cross-project tests pass; control tools accept no arbitrary cwd.
+
+### PR-10: Add the activity state machine and revisions
+
+Issues:
+
+- implement legal transitions and terminal states
+- require `expected_revision` on every mutation
+- add idempotency, cancellation, and restart reconciliation
+
+Exit criteria: transition-table, concurrency, duplicate-request, stale-event, and recovery tests pass; mismatches return `STALE_REVISION`.
+
+## 6. Epic D — Bounded MCP orchestration
+
+### PR-11: Split MCP data and control planes
+
+Issues:
+
+- preserve read-only workspace tools behind the V1 security policy
+- add high-level task/approval tools only
+- validate caller scope, project identity, input size, and mutation revision
+
+Exit criteria: MCP schemas and authorization tests pass; no raw shell, generic write, unrestricted git, or cwd input exists.
+
+### PR-12: Add context projections
+
+Issues:
+
+- implement `compact`, `standard`, and bounded `debug` views
+- support `since_revision` and explicit unchanged responses
+- sanitize and cap event/evidence output
+
+Exit criteria: snapshot, redaction, size-limit, and unchanged-response tests pass; normal polling does not replay full history.
+
+## 7. Epic E — Verification, review, and policy
+
+### PR-13: Add deterministic verification
+
+Issues:
+
+- detect project check commands with explicit configuration precedence
+- run required checks in the Codex/workspace boundary
+- persist exit code, status, duration, timestamp, repository revision, and sanitized output references
+
+Exit criteria: required failures block acceptance; stale or missing evidence cannot be attached to a newer revision.
+
+### PR-14: Add independent reviewer orchestration
+
+Issues:
+
+- create a reviewer in a distinct Codex thread/worktree by default
+- supply goal, success criteria, actual diff, relevant code, and verification evidence
+- resolve `ACCEPTED` and `FIX_REQUIRED` without trusting implementer summaries
+
+Exit criteria: independence and evidence-binding tests pass; fix loops are bounded and auditable.
+
+### PR-15: Add capability policy and approvals
+
+Issues:
+
+- model sandbox, network, secrets, deployment, git push, and production side effects separately
+- route approvals with actor, scope, expiry, revision, and idempotency
+- ensure workspace content cannot create or widen capability grants
+
+Exit criteria: deny/default, approval replay, expiry, cross-project, prompt-injection, and escalation tests pass.
+
+## 8. Epic F — Recovery, cleanup, and release
+
+### PR-16: Add recovery and failure injection
+
+Issues:
+
+- reconcile bridge, App Server, tunnel, database, and repository observations after restart
+- inject crashes at dispatch, execution, evidence write, review, and transition boundaries
+- map unresolved ambiguity to `RECOVERY_REQUIRED`
+
+Exit criteria: crash matrix passes with no false `DONE`, lost approval, or duplicated side effect.
+
+### PR-17: Migrate state and remove legacy core paths
+
+Issues:
+
+- import supported V1 metadata with backup, validation, and rollback
+- delete manual execution records, UI preferences, and sandbox-state writable-root requirements only after replacement
+- keep Cloudflare/auth/Computer Use in an explicit compatibility package if still supported
+
+Exit criteria: migration is repeatable and reversible; replacement coverage is green; core dependency checks confirm legacy isolation.
+
+### PR-18: Beta E2E and release gate
+
+Issues:
+
+- run supported ChatGPT/Secure MCP/Codex App Server E2E profiles
+- verify read-only and full-control capability profiles where product availability permits
+- publish compatibility matrix, migration guide, threat model, operational runbook, and known limitations
+
+Exit criteria: all required security, recovery, version-compatibility, and E2E gates pass; unsupported availability is documented rather than hidden by fallback.
+
+## 9. PR-01 verification record
+
+Fill this section from the final PR-01 run:
+
+| Check | Baseline | PR-01 head |
+| --- | --- | --- |
+| build | pass | pass |
+| typecheck | pass | pass |
+| test | 15 files / 164 tests pass | 15 files / 164 tests pass |
+
+PR-02 readiness is a release-manager judgment after PR-01 review. This document does not authorize starting PR-02.

--- a/docs/migration-plan-v2.md
+++ b/docs/migration-plan-v2.md
@@ -1,0 +1,62 @@
+# codex-with-chatgpt 2.0 Migration Plan
+
+Baseline: `a9f91cd98df1bc82686f57d5bc2b2993394c93be`
+
+## Goal
+
+Move from the current bridge-centered implementation to a Codex App Server-first architecture without changing baseline behavior in PR-01.
+
+## Scope of PR-01
+
+This pull request is documentation-only:
+
+- no runtime behavior changes
+- no API changes
+- no dependency changes
+- no file moves for source code
+
+## Planned epics
+
+### Epic 1: Architecture contract
+
+- define the V2 architectural boundary
+- document what stays in core and what moves out
+- preserve current workspace security semantics
+
+### Epic 2: Project Registry
+
+- derive workspace identity from registry metadata
+- avoid exposing raw cwd details to higher layers
+- keep workspace-to-execution mapping explicit
+
+### Epic 3: Durable state
+
+- move long-lived session and coordination state to SQLite
+- keep secrets and workspace binding outside the project tree
+- preserve owner-only permissions
+
+### Epic 4: Execution split
+
+- separate planning/review from execution
+- keep Codex App Server as the primary execution path
+- keep deterministic verification before review
+
+### Epic 5: Transport and compatibility
+
+- make Secure MCP Tunnel the default transport
+- keep any legacy compatibility paths isolated from core
+- forbid silent fallback between transports
+
+## Non-goals for PR-01
+
+- no code migration
+- no CLI changes
+- no auth/runtime refactor
+- no test expectation updates beyond verification runs
+
+## Acceptance bar
+
+- baseline tests still pass
+- build and typecheck still pass
+- docs clearly distinguish current state from future state
+- no runtime diff is introduced


### PR DESCRIPTION
## Summary

PR-01 establishes the documentation-only foundation for codex-with-chatgpt 2.0 from baseline `a9f91cd98df1bc82686f57d5bc2b2993394c93be`.

- define the target V2 architecture and trust boundaries
- define the PR-01 through PR-18 migration sequence
- record six architecture decisions
- add concise repository instructions with the V2 invariants
- keep runtime behavior, dependencies, APIs, and workspace security semantics unchanged

## Key decisions

- ChatGPT thinks; Codex works
- Codex App Server is the primary execution backend
- Secure MCP Tunnel is the default transport
- Computer Use is outside the core dependency graph
- Project Registry resolves opaque project IDs and does not expose arbitrary `cwd`
- SQLite is the durable state store
- silent fallback is forbidden

## Verification

- `pnpm build` — pass
- `pnpm typecheck` — pass
- `pnpm test` — 15 files / 164 tests pass
- baseline diff — only `AGENTS.md` and the eight requested documentation files

PR-02 has not been started and is not authorized by this PR.
