### PR TITLE
fix: Quick Tunnel timeout on Windows; git_status leaks ignored names

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -122,6 +122,10 @@ const gitStatusOutputSchema = {
   unstaged: z.array(gitChangeOutputSchema),
   untracked: z.array(z.string()),
   conflicted: z.array(z.string()),
+  hidden: z.object({
+    changes: z.number().int().nonnegative(),
+    conflicts: z.number().int().nonnegative(),
+  }),
 };
 
 const gitDiffOutputSchema = {
@@ -317,7 +321,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "git.read");
       if (denied) return denied;
       try {
-        return okStructured(gitStatus(workspace.root));
+        return okStructured(gitStatus(workspace));
       } catch (error) {
         return mapError(error);
       }

--- a/src/tunnel/cloudflared.ts
+++ b/src/tunnel/cloudflared.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { Resolver } from "node:dns/promises";
 import readline from "node:readline";
 import type { Logger } from "../logger/index.js";
 import { nullLogger } from "../logger/index.js";
@@ -10,6 +11,14 @@ const QUICK_TUNNEL_URL_RE = /https:\/\/[^\s|]+/gi;
 const QUICK_TUNNEL_HOST_RE = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\.trycloudflare\.com$/i;
 const HEALTH_CHECK_INTERVAL_MS = 250;
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+// Do not query the OS resolver until an external A record exists; an early
+// NXDOMAIN there can stick longer than the start timeout.
+const READINESS_RESOLVERS = ["1.1.1.1", "8.8.8.8"];
+const DNS_RETRY_INTERVAL_MS = 500;
+const DNS_QUERY_TIMEOUT_MS = 3_000;
+const UNAVAILABLE_FALLBACK_ROUNDS = 2;
+
+export type HostnameReadiness = "ready" | "not-ready" | "unavailable";
 
 function isBridgeHealth(payload: unknown): boolean {
   if (!payload || typeof payload !== "object") return false;
@@ -36,6 +45,48 @@ async function bridgeHealth(
   };
 }
 
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  if ("code" in error && typeof error.code === "string") return error.code;
+  if ("errors" in error && Array.isArray(error.errors)) {
+    for (const inner of error.errors) {
+      const code = errorCode(inner);
+      if (code) return code;
+    }
+  }
+  if ("cause" in error) return errorCode(error.cause);
+  return undefined;
+}
+
+function describeError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const code = errorCode(error);
+  return code ? `${error.message} [${code}]` : error.message;
+}
+
+function publicResolverProbe(): (hostname: string) => Promise<HostnameReadiness> {
+  const resolvers = READINESS_RESOLVERS.map((server) => {
+    const resolver = new Resolver({ timeout: DNS_QUERY_TIMEOUT_MS, tries: 1 });
+    resolver.setServers([server]);
+    return resolver;
+  });
+  return async (hostname) => {
+    const settled = await Promise.allSettled(resolvers.map((r) => r.resolve4(hostname)));
+    let positive = 0;
+    let negative = 0;
+    for (const result of settled) {
+      if (result.status === "fulfilled") positive += 1;
+      else {
+        const code = errorCode(result.reason);
+        if (code === "ENOTFOUND" || code === "ENODATA" || code === "ENOENT") negative += 1;
+      }
+    }
+    if (negative > 0) return "not-ready";
+    if (positive > 0) return "ready";
+    return "unavailable";
+  };
+}
+
 /** Extract a Quick Tunnel public URL from a cloudflared log line. */
 export function parseQuickTunnelUrl(line: string): string | null {
   for (const match of line.matchAll(QUICK_TUNNEL_URL_RE)) {
@@ -53,6 +104,8 @@ export function parseQuickTunnelUrl(line: string): string | null {
 
 export interface CloudflaredQuickTunnelOptions {
   startTimeoutMs?: number;
+  /** Test seam. Must not query the OS resolver. */
+  resolveImpl?: (hostname: string) => Promise<HostnameReadiness>;
   spawnImpl?: (
     command: string,
     args: string[],
@@ -72,6 +125,7 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
   private url: string | null = null;
   private lastError: string | null = null;
   private readonly startTimeoutMs: number;
+  private readonly resolveImpl: NonNullable<CloudflaredQuickTunnelOptions["resolveImpl"]>;
   private readonly spawnImpl: NonNullable<CloudflaredQuickTunnelOptions["spawnImpl"]>;
   private readonly fetchImpl: NonNullable<CloudflaredQuickTunnelOptions["fetchImpl"]>;
   private starting: Promise<string> | null = null;
@@ -83,6 +137,7 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
     options: CloudflaredQuickTunnelOptions = {}
   ) {
     this.startTimeoutMs = options.startTimeoutMs ?? 45_000;
+    this.resolveImpl = options.resolveImpl ?? publicResolverProbe();
     this.spawnImpl = options.spawnImpl ?? ((command, args, spawnOptions) => spawn(command, args, spawnOptions));
     this.fetchImpl = options.fetchImpl ?? ((input, init) => fetch(input, init));
   }
@@ -187,9 +242,29 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
         );
       };
 
+      const waitForDns = async (hostname: string): Promise<boolean> => {
+        let unavailableRounds = 0;
+        while (!settled && isAlive()) {
+          let verdict: HostnameReadiness = "unavailable";
+          try {
+            verdict = await this.resolveImpl(hostname);
+          } catch (error) {
+            this.lastError = describeError(error);
+          }
+          if (settled) return false;
+          if (verdict === "ready") return true;
+          if (verdict === "not-ready") unavailableRounds = 0;
+          else if (++unavailableRounds >= UNAVAILABLE_FALLBACK_ROUNDS) return true;
+          await new Promise((wait) => setTimeout(wait, DNS_RETRY_INTERVAL_MS));
+        }
+        if (!settled) fail(new Error("cloudflared exited before the public hostname resolved"));
+        return false;
+      };
+
       const waitForHealth = async (): Promise<void> => {
         const publicUrl = candidateUrl;
         if (!publicUrl) return;
+        if (!(await waitForDns(new URL(publicUrl).hostname))) return;
         while (!settled) {
           if (!isAlive()) {
             fail(new Error("cloudflared exited before the public health endpoint became ready"));
@@ -206,7 +281,8 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
             this.lastError = result.detail;
           } catch (error) {
             if (settled) return;
-            this.lastError = error instanceof Error ? error.message : String(error);
+            this.lastError = describeError(error);
+            this.logger.debug(`Quick tunnel health probe: ${this.lastError}`);
           }
           if (settled) return;
           await new Promise((resolveWait) => setTimeout(resolveWait, HEALTH_CHECK_INTERVAL_MS));

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -58,9 +58,14 @@ export interface GitStatusResult {
   unstaged: { path: string; change: string }[];
   untracked: string[];
   conflicted: string[];
+  /** Sensitive entries withheld. `conflicts` stays separate so a merge is not reported as clean. */
+  hidden: { changes: number; conflicts: number };
 }
 
-export function gitStatus(root: string): GitStatusResult {
+export function gitStatus(target: GitTarget): GitStatusResult {
+  const root = typeof target === "string" ? target : target.root;
+  const ignoreRules =
+    typeof target === "object" && target.ignoreRules ? target.ignoreRules : new IgnoreRules(root);
   const empty: GitStatusResult = {
     isRepo: false,
     branch: null,
@@ -71,10 +76,13 @@ export function gitStatus(root: string): GitStatusResult {
     unstaged: [],
     untracked: [],
     conflicted: [],
+    hidden: { changes: 0, conflicts: 0 },
   };
   const result = runGit(root, ["status", "--porcelain=v2", "--branch", "--", "."]);
   if (!result.ok) return empty;
-  const out: GitStatusResult = { ...empty, isRepo: true };
+  const out: GitStatusResult = { ...empty, hidden: { ...empty.hidden }, isRepo: true };
+  const withheld = (paths: string[]): boolean => paths.some((p) => ignoreRules.isSensitive(p));
+
   for (const line of result.stdout.split("\n")) {
     if (line.startsWith("# branch.head ")) {
       out.branch = line.slice("# branch.head ".length).trim();
@@ -89,18 +97,27 @@ export function gitStatus(root: string): GitStatusResult {
     } else if (line.startsWith("1 ") || line.startsWith("2 ")) {
       const parts = line.split(" ");
       const xy = parts[1];
-      const filePath = line.startsWith("2 ")
-        ? line.split("\t")[0]?.split(" ").slice(9).join(" ") + " -> " + (line.split("\t")[1] ?? "")
+      const isRename = line.startsWith("2 ");
+      const destination = isRename
+        ? (line.split("\t")[0]?.split(" ").slice(9).join(" ") ?? "")
         : parts.slice(8).join(" ");
-      const x = xy[0];
-      const y = xy[1];
-      if (x !== ".") out.staged.push({ path: filePath, change: x });
-      if (y !== ".") out.unstaged.push({ path: filePath, change: y });
+      const origin = isRename ? (line.split("\t")[1] ?? "") : null;
+      const rawPaths = origin === null ? [destination] : [destination, origin];
+      const filePath = origin === null ? destination : `${destination} -> ${origin}`;
+      if (withheld(rawPaths)) {
+        out.hidden.changes += (xy[0] !== "." ? 1 : 0) + (xy[1] !== "." ? 1 : 0);
+        continue;
+      }
+      if (xy[0] !== ".") out.staged.push({ path: filePath, change: xy[0] });
+      if (xy[1] !== ".") out.unstaged.push({ path: filePath, change: xy[1] });
     } else if (line.startsWith("? ")) {
-      out.untracked.push(line.slice(2));
+      const filePath = line.slice(2);
+      if (withheld([filePath])) out.hidden.changes += 1;
+      else out.untracked.push(filePath);
     } else if (line.startsWith("u ")) {
-      const parts = line.split(" ");
-      out.conflicted.push(parts.slice(10).join(" "));
+      const filePath = line.split(" ").slice(10).join(" ");
+      if (withheld([filePath])) out.hidden.conflicts += 1;
+      else out.conflicted.push(filePath);
     }
   }
   return out;

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -56,6 +56,35 @@ describe("gitStatus", () => {
     git(repo, "reset", "staged.txt");
     git(repo, "checkout", "--", "hello.txt");
   });
+
+  it("omits sensitive and .c2cignore'd paths, even as bare file names", () => {
+    write(repo, ".c2cignore", "private-notes/\n");
+    write(repo, ".env", "SECRET_KEY=leaked-env\n");
+    write(repo, "private-notes/secret.md", "CONFIDENTIAL DATA\n");
+    write(repo, "public.txt", "PUBLIC CONTENT\n");
+
+    const status = gitStatus(repo);
+    expect(status.untracked).toContain("public.txt");
+    expect(status.untracked).not.toContain(".env");
+    expect(status.untracked).not.toContain("private-notes/secret.md");
+    expect(status.hidden.changes).toBeGreaterThan(0);
+  });
+
+  // '>' is not a legal filename character on Windows, so the ambiguous
+  // rendering can only be exercised on POSIX.
+  it.skipIf(process.platform === "win32")(
+    "filters a rename whose pathname itself contains an arrow",
+    () => {
+      write(repo, ".c2cignore", "secret -> file.txt\n");
+      write(repo, "plain -> name.txt", "RENAMED CONTENT\n");
+      write(repo, "secret -> file.txt", "HIDDEN CONTENT\n");
+
+      const status = gitStatus(repo);
+      expect(status.untracked).toContain("plain -> name.txt");
+      expect(status.untracked).not.toContain("secret -> file.txt");
+      expect(status.hidden.changes).toBe(1);
+    }
+  );
 });
 
 describe("gitDiff pagination", () => {

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -40,12 +40,19 @@ class FakeCloudflaredProcess extends EventEmitter {
   });
 }
 
-function setupTunnel(fetchImpl: FetchImpl, startTimeoutMs = 1_000) {
+type ResolveImpl = NonNullable<CloudflaredQuickTunnelOptions["resolveImpl"]>;
+
+function setupTunnel(
+  fetchImpl: FetchImpl,
+  startTimeoutMs = 1_000,
+  resolveImpl: ResolveImpl = async () => "ready"
+) {
   const child = new FakeCloudflaredProcess();
   const spawnImpl = vi.fn(() => child as unknown as ChildProcess);
   const tunnel = new CloudflaredQuickTunnel(undefined, "cloudflared", {
     spawnImpl,
     fetchImpl,
+    resolveImpl,
     startTimeoutMs,
   });
   return { child, spawnImpl, tunnel };
@@ -97,6 +104,8 @@ describe("parseQuickTunnelUrl", () => {
   });
 });
 
+
+
 describe("CloudflaredQuickTunnel", () => {
   it("resolves only after the public health endpoint identifies the bridge", async () => {
     const fetchImpl = vi.fn(async () => healthResponse());
@@ -115,6 +124,83 @@ describe("CloudflaredQuickTunnel", () => {
       signal: expect.any(AbortSignal),
     });
     expect(tunnel.status()).toMatchObject({ running: true, url: QUICK_URL });
+    await tunnel.stop();
+  });
+
+  it("does not probe over HTTP until the public hostname is ready", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(async () => healthResponse());
+      const resolveImpl = vi
+        .fn<ResolveImpl>()
+        .mockResolvedValueOnce("not-ready")
+        .mockResolvedValueOnce("not-ready")
+        .mockResolvedValue("ready");
+      const { child, tunnel } = setupTunnel(fetchImpl, 20_000, resolveImpl);
+      const starting = tunnel.start(3333);
+      announceUrl(child);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resolveImpl).toHaveBeenCalledWith("random-words-here-1234.trycloudflare.com");
+      expect(fetchImpl).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(600);
+      expect(fetchImpl).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(600);
+      await expect(starting).resolves.toBe(QUICK_URL);
+      expect(fetchImpl).toHaveBeenCalled();
+      await tunnel.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to HTTP when public DNS probes are unreachable", async () => {
+    const fetchImpl = vi.fn(async () => healthResponse());
+    const resolveImpl = vi.fn<ResolveImpl>().mockResolvedValue("unavailable");
+    const { child, tunnel } = setupTunnel(fetchImpl, 5_000, resolveImpl);
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+
+    await expect(starting).resolves.toBe(QUICK_URL);
+    expect(fetchImpl).toHaveBeenCalled();
+    await tunnel.stop();
+  });
+
+  it("does not treat NXDOMAIN as another unavailable round", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(async () => healthResponse());
+      const resolveImpl = vi
+        .fn<ResolveImpl>()
+        .mockResolvedValueOnce("unavailable")
+        .mockResolvedValueOnce("not-ready")
+        .mockResolvedValue("ready");
+      const { child, tunnel } = setupTunnel(fetchImpl, 20_000, resolveImpl);
+      const starting = tunnel.start(3333);
+      announceUrl(child);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchImpl).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(600);
+      expect(fetchImpl).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(600);
+      await expect(starting).resolves.toBe(QUICK_URL);
+      expect(fetchImpl).toHaveBeenCalled();
+      await tunnel.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts probing immediately when the hostname already resolves", async () => {
+    const fetchImpl = vi.fn(async () => healthResponse());
+    const { child, tunnel } = setupTunnel(fetchImpl);
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+
+    await expect(starting).resolves.toBe(QUICK_URL);
     await tunnel.stop();
   });
 


### PR DESCRIPTION
Two independent Windows/setup bugs found while using C2C as the ChatGPT planning brain.

## 1. `c2c setup` times out on Windows

Quick Tunnel prints `https://<new>.trycloudflare.com` before the name resolves. Probing `/health` immediately makes an OS-mediated lookup fail. On this machine the configured recursive resolver (`192.168.100.1`) then never answered that name again within 90s, so the 45s start timeout always won.

Measured from the URL announcement:

| vantage | result |
| --- | --- |
| 1.1.1.1 | A record at +3.1s |
| 8.8.8.8 | A record at +4.1s |
| OS resolver / `dns.lookup` / `fetch` after an early query | never (90s) |
| first HTTP probe delayed 15s, no earlier OS query | HTTP 200 |

Fix: wait on public resolvers (1.1.1.1 and 8.8.8.8) before the HTTP probe, so the first OS lookup happens when the name is live.

- NXDOMAIN / ENOTFOUND from any vantage → keep waiting
- both vantages unreachable (blocked UDP/53) → fall back to the original HTTP loop after two rounds (no corporate-network regression)
- `startTimeoutMs` stays 45s and is not rearmed

After the fix, `c2c setup` on this host: 10s, 11s, 18s, 11s (4/4).

## 2. `git_status` leaked ignored file names

`git_diff` already filters through `IgnoreRules`. `git_status` returned the names. Content stayed protected; a filename can still be sensitive.

Fix: filter porcelain v2 **raw** paths (destination + origin on a TAB-separated rename) before rendering `a -> b`. Report `hidden: { changes, conflicts }` so a dirty or conflicted tree does not look clean. `gitStatus` accepts the workspace object and reuses `ignoreRules`, same as `git_diff`.

## Verification

- `pnpm build` clean
- `pnpm test` 169 passed, 1 skipped (`>` is not a legal Windows filename; the arrow-in-name case is POSIX-only)
- New tests fail with these source files stashed
