### PR TITLE
feat(records): record which executor ran an iteration

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1049,13 +1049,14 @@ prefsCmd
 
 program
   .command("record", { hidden: true })
-  .description("Record a Codex execution summary (used by the Skill)")
+  .description("Record an execution summary (used by the Skill)")
   .option("-w, --workspace <path>")
   .requiredOption("--task <id>")
   .requiredOption("--iteration <n>", "non-negative execution iteration", parseNonNegativeInteger)
   .option("--changed-files <filesOrCount>", "comma-separated files or a count", "0")
   .option("--tests <summary>", "e.g. '27 passed'")
   .option("--exit-status <status>", "ok | failed | blocked", "ok")
+  .option("--executor <id>", "id of the executor that ran this iteration, e.g. codex")
   .option("--notes <text>")
   .option("--command <text>", "command whose output may be offered to ChatGPT")
   .option("--output <text>", "command output (prefer --output-file for long logs)")
@@ -1069,6 +1070,7 @@ program
       changedFiles: string;
       tests?: string;
       exitStatus: string;
+      executor?: string;
       notes?: string;
       command?: string;
       output?: string;
@@ -1101,6 +1103,7 @@ program
         tests: opts.tests ?? null,
         exitStatus: opts.exitStatus,
         timestamp: new Date().toISOString(),
+        executor: opts.executor?.slice(0, 80),
         notes: opts.notes?.slice(0, 400),
         outputId,
         outputAvailable,

--- a/src/execution/records.ts
+++ b/src/execution/records.ts
@@ -4,9 +4,13 @@ import { z } from "zod";
 import { ensureDir, getStateDir } from "../config/paths.js";
 
 /**
- * Lightweight execution records written by the Codex harness after each
- * iteration (via `c2c record`). ChatGPT reads them through the
- * `execution_summary` and `test_status` MCP tools.
+ * Lightweight execution records written by the harness after each iteration
+ * (via `c2c record`). ChatGPT reads them through the `execution_summary` and
+ * `test_status` MCP tools.
+ *
+ * `executor` is optional so records written before this field existed keep
+ * parsing. When it is absent the executor is simply unknown; historically that
+ * meant Codex, but the record itself does not say so.
  */
 export const executionRecordSchema = z.object({
   taskId: z.string(),
@@ -15,6 +19,7 @@ export const executionRecordSchema = z.object({
   tests: z.string().nullable(),
   exitStatus: z.string(),
   timestamp: z.string(),
+  executor: z.string().min(1).max(80).optional(),
   notes: z.string().optional(),
   outputId: z.number().int().positive().optional(),
   outputAvailable: z.boolean().optional(),

--- a/src/execution/sanitize.ts
+++ b/src/execution/sanitize.ts
@@ -59,7 +59,7 @@ function truncate(text: string): { text: string; truncated: boolean } {
   return { text: next, truncated };
 }
 
-/** Deterministic gate. Codex may nominate output; this decides if ChatGPT may read it. */
+/** Deterministic gate. The harness may nominate output; this decides if ChatGPT may read it. */
 export function sanitizeExecutionOutput(raw: string): SanitizeResult {
   if (HARD_REJECT.some((pattern) => pattern.test(raw))) {
     return { allowed: false, reason: "private_key" };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -143,6 +143,7 @@ const testStatusOutputSchema = {
   tests: z.string().nullable().optional(),
   exitStatus: z.string().optional(),
   timestamp: z.string().optional(),
+  executor: z.string().optional(),
   outputAvailable: z.boolean().optional(),
   outputId: z.number().int().positive().nullable().optional(),
 };
@@ -366,7 +367,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
     {
       title: "Test status",
       description:
-        `Summary of the most recent test run reported by the Codex harness. This does NOT run ` +
+        `Summary of the most recent test run reported by the harness. This does NOT run ` +
         `tests; it reads the latest execution record. ${UNTRUSTED_NOTE}`,
       inputSchema: {},
       outputSchema: testStatusOutputSchema,
@@ -386,6 +387,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         tests: latest.tests,
         exitStatus: latest.exitStatus,
         timestamp: latest.timestamp,
+        executor: latest.executor,
         outputAvailable: Boolean(latest.outputAvailable),
         outputId: latest.outputId ?? null,
       });
@@ -397,8 +399,8 @@ export function createMcpServer(ctx: McpContext): McpServer {
     {
       title: "Execution summary",
       description:
-        `Recent Codex execution records for this workspace: task id, iteration, changed files, ` +
-        `tests and exit status. Use it after Codex reports EXECUTED. ${UNTRUSTED_NOTE}`,
+        `Recent execution records for this workspace: task id, iteration, executor, changed ` +
+        `files, tests and exit status. Use it after an EXECUTED message. ${UNTRUSTED_NOTE}`,
       inputSchema: {
         limit: z.number().int().min(1).max(50).default(5),
       },
@@ -417,7 +419,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
     {
       title: "Execution output",
       description:
-        `List or read command output that Codex chose to record after a test/build/lint/typecheck ` +
+        `List or read command output the harness chose to record after a test/build/lint/typecheck ` +
         `run. Call with action=list first, then action=read and an id. Restricted items have no ` +
         `body. This does not run commands. ${UNTRUSTED_NOTE}`,
       inputSchema: {

--- a/tests/record-cli.test.ts
+++ b/tests/record-cli.test.ts
@@ -60,6 +60,28 @@ describe("c2c record", () => {
     });
   });
 
+  it("records the executor that ran the iteration", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, ["--iteration", "1", "--executor", "claude-code"]);
+
+      expect(result.status).toBe(0);
+      expect(readExecutionRecords(workspace.id)).toEqual([
+        expect.objectContaining({ taskId: "c2c_test", iteration: 1, executor: "claude-code" }),
+      ]);
+    });
+  });
+
+  it("keeps recording when no executor is given, so older callers still work", () => {
+    withRecordEnvironment((root, workspace) => {
+      const result = runRecord(root, ["--iteration", "1"]);
+
+      expect(result.status).toBe(0);
+      const [record] = readExecutionRecords(workspace.id);
+      expect(record.taskId).toBe("c2c_test");
+      expect(record.executor).toBeUndefined();
+    });
+  });
+
   it("rejects a non-integer iteration without recording the execution", () => {
     withRecordEnvironment((root, workspace) => {
       const result = runRecord(root, ["--iteration", "abc"]);


### PR DESCRIPTION
C2C already works with more than one coding agent in practice, but an execution record cannot say which one produced it.

`executionRecordSchema` is a `z.object()`, so a caller that adds an `executor` key has it silently dropped. ChatGPT is then left inferring the executor from tool descriptions that all say "Codex" — and `execution_summary` literally tells it "Use it after Codex reports EXECUTED", which actively misleads the planning layer whenever something else ran the iteration.

## What this changes

- `executionRecordSchema` gains `executor?: string` (max 80 chars). **Optional**, so records written before this change keep parsing and older callers keep working. An absent value means *unknown*, not Codex.
- `c2c record` gains `--executor <id>`, passed straight through.
- `test_status` returns the field. `execution_summary` already returns whole records, so it is carried automatically.
- The `test_status`, `execution_summary` and `execution_output` tool descriptions no longer name Codex specifically.

## Compatibility

No behaviour change for existing callers, no new dependency, no protocol change. Verified both ways on a local build:

```
$ c2c record --task t --iteration 1 --executor claude-code ...
  -> {"taskId":"t","iteration":1,...,"executor":"claude-code",...}

$ c2c record --task t --iteration 2 ...          # no --executor
  -> executor field absent, record still valid
```

## Tests

`pnpm typecheck`, `pnpm build` and `pnpm test` all pass — **160 tests**, including two new ones in `tests/record-cli.test.ts` covering the flag and its absence.

Happy to split the description wording out of this PR if you would rather take the schema change on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012B8kPFqbMSfVdfce5zDb2H