### PR TITLE
fix(skill): recover ChatGPT Project navigation errors

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -18,6 +18,38 @@ The C2C Bridge gives ChatGPT read-only MCP access to the current workspace, so
 control messages between you and ChatGPT stay tiny (< 1 KB) — ChatGPT pulls
 whatever data it needs by itself.
 
+## Browser navigation recovery (takes precedence over direct-goto rules below)
+
+In the Windows in-app browser, a direct load of a ChatGPT Project collection
+can render only a `Retry` / `重试` button, while following the Project link
+from a working chat renders the same collection correctly (observed 2026-09-09).
+Treat this as a page error, not generation, a missing composer, or a pairing failure.
+
+- Reuse the existing tab. Prefer a visible same-site link to the intended chat or
+  Project over `goto`. Verify its href identifies the saved Project. The
+  `Open … project` / `打开“… ”项目` link in a working chat is an allowed route;
+  do not interpret the URLs-only guidance below as forbidding this link.
+- When only Retry is present, try it once. If the error remains, open the last
+  verified chat URL from this task's context/checkpoint, inspect the DOM, then
+  click its Project link. This is a navigation anchor only: do not submit a new
+  task to that old chat when the user requested a new conversation.
+- On the collection, require the project chat list and new-chat composer before
+  continuing. Create the requested new chat with that composer. Preserve the
+  old saved URL/checkpoint until the replacement chat passes workspace validation;
+  do not run `session clear` as a prerequisite for creating a replacement.
+- After navigating, use one bounded DOM check. An explicit Retry-only page is
+  an error; an ordinary tool timeout alone is not. If recovery fails, retain the
+  tab and checkpoint and report the actual page failure instead of repeatedly
+  reloading, repairing pairing, or waiting for a nonexistent response.
+- Record INIT / GPT_PLAN or EXECUTED_SENT / GPT_REVIEW only after the submitted
+  message is visibly in the chat. If submission is uncertain, inspect first;
+  never resend solely because a browser call timed out.
+
+Use the current browser API exposed by the tool: `cua.getState()` then
+`cua.getTab(id, {browser})`, with the documented `tab.playwright` DOM/locator
+API when available. Do not bootstrap obsolete browser runtimes or assume a
+browser control method exists without its returned documentation.
+
 **Golden rules**
 
 1. NEVER paste file contents, diffs, or logs into ChatGPT. ChatGPT reads them through MCP.


### PR DESCRIPTION
## Summary
Codex with ChatGPT can record a local checkpoint as `INIT / waiting for GPT_PLAN` before the ChatGPT message has been visibly submitted. When Project collection navigation then fails with a Retry-only page, the workflow waits indefinitely for a response that was never sent.

## Reproduction
1. Use a Project-mode workspace with a saved Project collection and one existing chat.
2. Start a task that must open a new chat inside the Project.
3. Navigate directly to the Project collection URL in the Codex in-app browser.
4. If the collection page renders only `Retry`, the flow may still persist `INIT / waiting for GPT_PLAN`.
5. The ChatGPT conversation contains no new INIT message, while the local session says it is waiting for PLAN.
6. Reaching the Project by clicking `Open project` from a working chat loads the collection successfully.

## Expected behavior
The workflow should persist `INIT / waiting for GPT_PLAN` only after the INIT message is visibly present in the target ChatGPT conversation. A Retry-only page should be classified as a navigation error, and recovery should use a working same-site navigation anchor before creating a new Project chat.

## Evidence
- Local connection health checks were green.
- The Project page repeatedly failed on direct load/reload with only Retry.
- The same Project loaded via the existing chat's Project link and exposed the new-chat composer.
- The saved checkpoint previously reported `INIT / GPT_PLAN` although the target chat had no INIT message.

## Suggested fix
Add a post-submit visibility check before writing the waiting checkpoint, detect Retry-only pages, and recover through the existing chat's Project link when available. Preserve the old chat pointer until the replacement chat passes workspace validation.
