### PR TITLE
feat: add shared multi-workspace MCP gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Detailed docs below are in English · 详细中文文档见 **[README.zh-CN.md](
    ~/.codex/skills/codex-with-chatgpt/SKILL.md，并把文件中
    "The codex-with-chatgpt checkout lives at:" 那一行的路径改成实际克隆路径。
 5. 首次配置：按 SKILL.md 里的 first-time setup 流程执行
-  （运行 c2c setup，用内置浏览器打开 ChatGPT 配置连接器并输入配对码）。
+   （运行 c2c gateway setup，用内置浏览器打开 ChatGPT 配置一次共享连接器并输入配对码）。
    全程只用内置浏览器，禁止打开任何第三方浏览器。
 6. 只有遇到需要我登录（ChatGPT / Cloudflare）、验证码或两步验证时才叫我，
    而且一次只告诉我一个动作。
@@ -110,7 +110,7 @@ just see:
 Codex with ChatGPT
 
 ✓ Project detected
-✓ Workspace Bridge started
+✓ Shared Gateway started
 ✓ Secure connection established
 ✓ ChatGPT connected
 ✓ File read test passed
@@ -129,16 +129,22 @@ style until you ask to switch.
 
 ### Optional stable hostname
 
-The default public address is a temporary Cloudflare URL. It changes when the
-bridge restarts, and Codex repairs ChatGPT by deleting that workspace's
-connector and adding it again.
+The default public address is a temporary Cloudflare URL. With the shared
+Gateway there is one public endpoint and one ChatGPT connector for the machine;
+new workspaces are attached automatically by Codex and do not create another
+connector.
 
 If you have a Cloudflare account and a domain already on Cloudflare, first-time
 setup (and the next coding session, once) will ask whether you want a stable
-hostname such as `c2c-<project>.your-domain.com`. That path opens a browser so
+hostname such as `example.your-domain.com`. That path opens a browser so
 you can authorize Cloudflare. After that, the ChatGPT connector keeps working
 across restarts. If you skip it, or the login fails, Codex stays on the temporary
 address — same features, just a slower repair.
+
+When an existing per-workspace installation is upgraded to the shared Gateway,
+the first Gateway start migrates its local OAuth state once. A stable connector
+keeps working without another pairing; if no valid old authorization remains,
+`c2c gateway setup` prints a new pairing code.
 
 Credentials stay in the OS app state directory, not in the project.
 
@@ -154,16 +160,16 @@ Credentials stay in the OS app state directory, not in the project.
             Data Plane  │          │ Control Plane (<1 KB messages)
                         ▼          │
              ┌─────────────────────┐
-             │      C2C Bridge     │   loopback-only HTTP server
-             │  read-only MCP      │   OAuth 2.1 + one-time pairing code
-             │  OAuth + Pairing    │   Cloudflare Quick Tunnel
+             │      C2C Gateway    │   loopback-only HTTP server
+             │  read-only MCP      │   one OAuth credential
+             │  OAuth + Pairing    │   short-lived workspace leases
              │  Tunnel Manager     │
              └──────────┬──────────┘
-                        │  read-only
+                        │  read-only, opaque workspace_id
                         ▼
              ┌─────────────────────┐          ┌─────────────────────┐
-             │   Local Workspace   │◀─────────│    Codex Harness    │
-             └─────────────────────┘ edit/git │ shell / tests / fix │
+             │ Attached Workspaces │◀─────────│    Codex Harness    │
+             └─────────────────────┘ attach   │ shell / tests / fix │
                                               └─────────────────────┘
 ```
 
@@ -182,9 +188,13 @@ Credentials stay in the OS app state directory, not in the project.
 
 - **Read-only by construction**: write/delete/shell/commit tools simply do not
   exist on the server. No prompt injection can enable them.
-- **One workspace = one boundary**: every token is bound to a single workspace;
-  path containment uses canonical realpaths (symlink/`../`/absolute-path escapes
-  are all blocked and tested).
+- **Gateway lease boundary**: the OAuth credential is scoped to this local
+  Gateway, while each MCP call resolves the active opaque workspace id from a
+  short-lived lease created by the local Codex process. Raw Windows paths are
+  never accepted, and a non-active attached workspace cannot be selected by the
+  model.
+  Each workspace still uses canonical realpaths (symlink/`../`/absolute-path
+  escapes are all blocked and tested).
 - **Sensitive files never leave**: `.env*`, keys, SSH, credentials are denied by
   default (`.env.example` allowed); `.c2cignore` adds your own rules.
 - **Knowing the URL grants nothing**: the public MCP endpoint requires OAuth 2.1
@@ -203,9 +213,10 @@ pnpm install
 pnpm build          # -> dist/, exposes the `c2c` bin
 pnpm test           # vitest: 146 tests (path security, OAuth, pairing, MCP e2e)
 
-c2c setup           # bridge + tunnel + pairing code, all in one
+c2c gateway setup   # shared Gateway + tunnel + first pairing code
+c2c gateway attach  # automatic per-task workspace attachment
 c2c sandbox-allow   # whitelist the settings dir in Codex (macOS + Windows)
-c2c status / doctor / pair / unpair / logs / stop
+c2c status / doctor / gateway status / gateway pair / stop
 ```
 
 Requirements: Node.js >= 20, git. `cloudflared` for the public connection
@@ -218,7 +229,8 @@ Docs: [architecture](docs/architecture.md) · [protocol](docs/protocol.md) ·
 
 ```
 src/
-  bridge/     loopback HTTP server, port recovery, admin API
+  gateway/    shared loopback HTTP server, workspace leases, admin API
+  bridge/      legacy single-workspace compatibility server
   mcp/        9 read-only tools, stateless Streamable HTTP
   auth/       OAuth 2.1 (PKCE, DCR, refresh rotation, revocation)
   pairing/    one-time pairing codes (CSPRNG, TTL, rate limits)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@ Agent（Codex），然后去倒杯咖啡：
    ~/.codex/skills/codex-with-chatgpt/SKILL.md，并把文件中
    "The codex-with-chatgpt checkout lives at:" 那一行的路径改成实际克隆路径。
 5. 首次配置：按 SKILL.md 里的 first-time setup 流程执行
-  （运行 c2c setup，用内置浏览器打开 ChatGPT 配置连接器并输入配对码）。
+  （运行 c2c gateway setup，用内置浏览器打开 ChatGPT 配置一次共享连接器并输入配对码）。
    全程只用内置浏览器，禁止打开任何第三方浏览器。
 6. 只有遇到需要我登录（ChatGPT / Cloudflare）、验证码或两步验证时才叫我，
    而且一次只告诉我一个动作。
@@ -58,7 +58,7 @@ Codex 会自动完成所有配置，你只会看到：
 Codex with ChatGPT
 
 ✓ 当前项目已识别
-✓ Workspace Bridge 已启动
+✓ 共享 Gateway 已启动
 ✓ 安全连接已建立
 ✓ ChatGPT 已连接
 ✓ 文件读取测试通过
@@ -70,9 +70,13 @@ Ready.
 
 ### 可选的固定域名
 
-默认公网地址是临时的，桥重启后会变。Codex 会删掉这个项目的 ChatGPT 插件再按新地址加回去。
+默认公网地址是临时的。共享 Gateway 只配置一个 ChatGPT 连接器；新工作区由 Codex 自动附加，不会再创建连接器。
 
-如果你有 Cloudflare 账号，并且域名已经加在 Cloudflare 上，首次配置时（老用户则在下一次编码时问一次）会问你要不要用固定域名，例如 `c2c-<项目>.你的域名`。选是的话，浏览器里授权一次 Cloudflare 即可。之后重启一般不用再改插件。没有账号、不想用、登录失败：继续用临时地址，功能一样，只是修复更慢。
+如果你有 Cloudflare 账号，并且域名已经加在 Cloudflare 上，首次配置时会问你要不要用固定域名，例如 `example.你的域名`。选是的话，浏览器里授权一次 Cloudflare 即可。之后重启一般不用再改连接器。没有账号、不想用、登录失败：继续用临时地址，功能一样。
+
+从旧版“每个工作区一个 Bridge”升级到共享 Gateway 时，第一次启动会在本机一次性迁移旧的
+OAuth 状态。固定连接器会继续复用，不需要再次配对；只有旧授权已经失效时，`c2c gateway setup`
+才会打印新的配对码。
 
 凭证放在系统目录，不进项目。
 
@@ -88,16 +92,16 @@ Ready.
               数据面    │          │ 控制面（消息 < 1 KB）
                         ▼          │
              ┌─────────────────────┐
-             │      C2C Bridge     │   仅监听本机回环地址
-             │  只读 MCP           │   OAuth 2.1 + 一次性配对码
-             │  OAuth + 配对       │   Cloudflare Quick Tunnel
+             │      C2C Gateway   │   仅监听本机回环地址
+             │  只读 MCP           │   单一 OAuth 凭据
+             │  OAuth + 配对       │   短期工作区租约
              │  Tunnel 管理        │
              └──────────┬──────────┘
-                        │  只读
+                        │  只读，不透明 workspace_id
                         ▼
              ┌─────────────────────┐          ┌─────────────────────┐
-             │     本地工作区      │◀─────────│    Codex Harness    │
-             └─────────────────────┘ 编辑/git │  Shell / 测试 / 修复 │
+             │    已附加工作区     │◀─────────│    Codex Harness    │
+             └─────────────────────┘ 自动附加 │  Shell / 测试 / 修复 │
                                               └─────────────────────┘
 ```
 
@@ -115,8 +119,10 @@ Ready.
 
 - **从构造上只读**：服务端根本不存在写文件/删除/Shell/提交类工具，任何提示
   注入都无法启用它们。
-- **一个工作区 = 一道边界**：每个令牌绑定单一工作区；路径校验基于规范化
-  realpath（symlink、`../`、绝对路径逃逸全部被拦截并有测试覆盖）。
+- **Gateway 租约边界**：OAuth 凭据只属于本机 Gateway，MCP 调用通过 Codex
+  自动创建的短期租约和 active 的不透明 `workspace_id` 解析工作区，不接受原始
+  Windows 路径；模型不能选择另一个已附加但非 active 的工作区。每个工作区仍
+  基于规范化 realpath 校验（symlink、`../`、绝对路径逃逸全部被拦截并有测试覆盖）。
 - **敏感文件永不外泄**：`.env*`、密钥、SSH、各类凭据默认拒绝
   （`.env.example` 放行）；`.c2cignore` 可追加自定义规则。
 - **知道 URL 不等于有权限**：公网 MCP 端点强制 OAuth 2.1（PKCE S256、动态
@@ -133,9 +139,10 @@ pnpm install
 pnpm build          # 产出 dist/，暴露 c2c 命令
 pnpm test           # vitest：146 个测试（路径安全、OAuth、配对、MCP 端到端）
 
-c2c setup           # 一条命令：Bridge + 隧道 + 配对码
+c2c gateway setup   # 一条命令：共享 Gateway + 隧道 + 首次配对码
+c2c gateway attach  # 每个任务自动附加当前工作区
 c2c sandbox-allow   # 把本地设置目录加入 Codex 沙箱白名单（macOS / Windows）
-c2c status / doctor / pair / unpair / logs / stop
+c2c status / doctor / gateway status / gateway pair / stop
 ```
 
 环境要求：Node.js >= 20、git；公网连接需要 `cloudflared`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,17 +10,17 @@
             Data Plane  │          │ Control Plane
                         ▼          │
              ┌─────────────────────┐
-             │      C2C Bridge     │
+             │      C2C Gateway    │
              │  MCP Server (RO)    │
              │  OAuth AS + PRM     │
              │  Pairing Manager    │
              │  Tunnel Manager     │
              │  Admin API (local)  │
              └──────────┬──────────┘
-                        │  read-only
+                        │  read-only + opaque workspace_id
                         ▼
              ┌─────────────────────┐
-             │   Local Workspace   │
+             │ Attached Workspaces │
              └──────────▲──────────┘
                         │ edit / shell / git / test
              ┌──────────┴──────────┐
@@ -34,13 +34,16 @@
 - **Computer Use = control plane**: tiny `[C2C]` state messages (< 1 KB).
 - **MCP = data plane**: ChatGPT pulls files/diffs/search results itself.
 - **Read-only by design**: no write/exec tools exist in V1 at all.
-- **Workspace is the security boundary**: one bridge = one workspace = one token audience.
+- **Gateway lease is the public boundary**: one Gateway and one connector serve
+  many workspaces, but each workspace must be attached locally and is resolved
+  only through an opaque id and a short-lived lease.
 
 ## Components (src/)
 
 | Module | Responsibility |
 | --- | --- |
 | `bridge/` | Express app assembly, loopback-only listener, port fallback, runtime state, admin API |
+| `gateway/` | Shared Express endpoint, automatic workspace leases, opaque workspace routing, Gateway runtime state |
 | `mcp/` | McpServer with 9 read-only tools; stateless Streamable HTTP transport (fresh server per request, JSON responses) |
 | `auth/` | OAuth 2.1 authorization server: discovery metadata (RFC 8414 + Protected Resource Metadata), dynamic client registration (RFC 7591), authorization-code + PKCE (S256 only), refresh rotation, revocation (RFC 7009). Opaque tokens stored as SHA-256 hashes |
 | `pairing/` | PairingCode lifecycle: CSPRNG generation, TTL, attempt limits, IP rate limit, one-time use |
@@ -53,8 +56,9 @@
 
 ## Request lifecycles
 
-**MCP call**: ChatGPT → tunnel (https) → bridge `/mcp` → bearer middleware
-(401/403) → stateless StreamableHTTP transport → tool handler → workspace layer
+**MCP call**: ChatGPT → tunnel (https) → Gateway `/mcp` → bearer middleware
+(401/403) → stateless StreamableHTTP transport → opaque workspace resolver →
+tool handler → workspace layer
 (path containment → ignore rules → pagination) → JSON result.
 
 **Authorization**: 401 with `WWW-Authenticate: resource_metadata=…` →
@@ -68,12 +72,12 @@ whether the occupant is a c2c bridge for the same workspace (reuse) or not
 runtime state file; users never see ports.
 
 **Tunnel**: default is a Cloudflare Quick Tunnel (`cloudflared tunnel --url …`).
-The URL changes per start, so `c2c doctor` can restart it and tell the Skill to
-Delete + recreate that workspace's ChatGPT connector. A workspace may instead
-choose a named hostname once (`c2c tunnel choose --mode named`). The Skill asks
-before the first public URL exists; `cloudflared tunnel login` is the only extra
-user step. Tunnel name, hostname and preference live under the OS state dir
-(`tunnels/<workspaceId>.json`), never in the project. Named starts use
+The URL changes per start, so the Gateway can restart it without creating a new
+connector for each workspace. A named hostname can be chosen once
+(`c2c tunnel choose --mode named`); the Gateway migrates an existing named
+binding to `tunnels/gateway.json`. The Skill asks before the first public URL
+exists; `cloudflared tunnel login` is the only extra user step. Tunnel name,
+hostname and preference live under the OS state dir, never in the project. Named starts use
 `cloudflared tunnel --url … run <name>` so the public URL stays stable. If named
 provisioning fails, C2C falls back to Quick Tunnel. If a named tunnel later
 drops, doctor asks for a Cloudflare re-login (`namedRepair`) instead of

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,9 +2,11 @@
 
 ## Trust boundaries
 
-1. **Workspace root** is the smallest authorization boundary. One bridge serves
-   exactly one workspace; every token is bound to `workspace_id`; a token for
-   project A returns 403 on project B's bridge.
+1. **Gateway lease** is the public authorization boundary. One Gateway serves
+   attached workspaces; the global OAuth token is accepted only by that Gateway,
+   and each MCP call resolves the active opaque `workspace_id` from a short-lived
+   lease. Raw filesystem paths and non-active workspace ids are never accepted
+   from the model.
 2. **Workspace content is untrusted.** README, comments, diffs may contain
    prompt injection. Every MCP tool description carries an explicit warning and
    tools never grant capabilities based on file content.
@@ -25,7 +27,7 @@
 | Symlink escape | Canonicalization resolves symlinks before the containment check (file and directory symlinks both covered by tests) |
 | Sensitive files | Deny-by-default patterns (.env*, keys, SSH, cloud creds, keychains…) enforced at resolve time — reads, listings, and search all pass through the same gate; `git diff` adds pathspec excludes; `.env.example` allowed |
 | Oversized file / diff DoS | read_file caps lines and bytes per response; git_diff paginates by byte offset with hard caps; search caps matches and file sizes |
-| Tunnel exposure | Bridge binds 127.0.0.1 only (refuses 0.0.0.0); the only public surface is HTTPS via the tunnel, protected by OAuth; `/health` reveals only a salted workspace hash |
+| Tunnel exposure | Gateway binds 127.0.0.1 only (refuses 0.0.0.0); the only public surface is HTTPS via the tunnel, protected by OAuth; `/health` reveals only the active opaque workspace id |
 | Admin API abuse | Loopback-only + random admin token (0600 runtime file) + requests with proxy headers (`cf-connecting-ip`, `x-forwarded-for`) rejected; unauthenticated probes get 404 |
 | Log credential leakage | Logger redacts token prefixes, bearer headers, token-like parameters, and pairing-code-shaped strings before writing |
 | Execution output leak | Codex may nominate test/build/lint logs; a local sanitizer redacts tokens, pairing-code-shaped strings and home paths, truncates size, and refuses private-key blocks entirely. Restricted items are listed without a body. ChatGPT still cannot run commands. |
@@ -35,15 +37,18 @@
 
 Scopes: `workspace.read`, `workspace.search`, `git.read`, `execution.read`,
 `offline_access`. Tools enforce scopes individually (`INSUFFICIENT_SCOPE`).
-Access tokens: 1 hour. Refresh tokens: 30 days, rotated. All tokens bound to
-`workspace_id` and `client_id`.
+Access tokens: 1 hour. Refresh tokens: 30 days, rotated. Gateway tokens are
+bound to the Gateway audience (`workspaceId: "*"`) and `client_id`; individual
+workspace access still requires a live local lease. Legacy single-workspace
+Bridge tokens remain bound to their concrete `workspace_id`.
 
 ## Storage
 
 State lives under the OS-convention app dir
 (`~/Library/Application Support/codex-with-chatgpt` on macOS), directories 0700,
 files 0600. Named-hostname preference and tunnel metadata live there too
-(`tunnels/<workspaceId>.json`) — never in the project. Only SHA-256 hashes of
+(`tunnels/<workspaceId>.json`, with the shared Gateway using `tunnels/gateway.json`)
+— never in the project. Workspace lease state is also local-only. Only SHA-256 hashes of
 tokens are persisted — a stolen state file does not yield usable bearer tokens.
 
 **V1 limitation**: client registrations and token hashes are file-based rather

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,29 +3,33 @@
 First move, always:
 
 ```
-c2c doctor
+c2c gateway doctor
 ```
 
-It checks Node, workspace, bridge, MCP, OAuth and tunnel — and repairs what it
-can (restarts the bridge, restarts the tunnel) without asking.
+It checks the shared Gateway, the current workspace lease, MCP, OAuth and the
+tunnel — and repairs what it can without asking.
 
 ## Common situations
 
-### "Bridge 未运行"
-`c2c start` (or let doctor do it). Bridge logs:
-`c2c logs`, or verbose: `c2c logs --verbose`.
+### "Gateway 未运行"
+`c2c gateway setup -w <workspace>` (or let `c2c gateway doctor` start it).
+Gateway logs are in the C2C state directory under `logs/gateway.out.log`.
 
-If doctor says the bridge state is **uncertain** (无法确认), do not start a
-second bridge and do not Delete the ChatGPT connector. Wait and run doctor
-again. The local process may still be running.
+If the Gateway state is **uncertain** (无法确认), do not start a second
+Gateway and do not change the ChatGPT connector. Wait and run the Gateway
+doctor again. The local process may still be running.
 
 ### Everything was quit and ChatGPT can no longer connect
-Quitting Codex / the terminal stops the public address. The next `c2c doctor`
-starts a new address and sets `chatgptRepair.needed`. The Skill should tell the
-user that the old address expired, then **Delete** THIS workspace's
-connector (`chatgptRepair.connectorName`) and create it again with the new
-address (never click Reconnect — the old URL is dead). Other workspaces keep
-their own connectors so two projects can stay connected at once.
+Quitting Codex / the terminal stops the public address. The next
+`c2c gateway doctor` restarts the shared Gateway and tunnel. With a named
+hostname, the existing global connector remains valid; with a temporary
+address, re-authorize the single global connector only when the address really
+changed.
+
+On the first start after upgrading from the old per-workspace Bridge, Gateway
+imports the local OAuth state once and rebinds it to the shared connector. No
+new pairing is needed while a valid refresh authorization exists. If the state
+was already revoked or expired, run `c2c gateway pair` and authorize once.
 
 Fixed ChatGPT pages for first-time setup and later repair (do not hunt the UI):
 
@@ -35,8 +39,8 @@ Fixed ChatGPT pages for first-time setup and later repair (do not hunt the UI):
   https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins
 
 ### Tunnel URL unreachable / ChatGPT says the connector is broken
-Same as above: `c2c doctor`, then Delete + recreate THIS workspace's
-connector if `chatgptRepair.needed`. Fresh pairing code: `c2c pair`.
+Same as above: `c2c gateway doctor`, then re-authorize the single global
+connector only if its address changed. Fresh pairing code: `c2c gateway pair`.
 If this workspace uses a stable hostname, doctor sets `namedRepair` instead —
 re-login to Cloudflare (`c2c tunnel login`) and doctor again. Do not Delete
 the connector; the address did not change.
@@ -44,7 +48,7 @@ the connector; the address did not change.
 ### I have a Cloudflare domain and want a stable hostname
 During first-time setup (or the next coding session, once), say you have a
 Cloudflare account and give the domain. Codex opens a browser for Cloudflare
-login, then keeps `c2c-<project>.your-domain.com`. To stay on the temporary
+login, then keeps one Gateway hostname such as `example.your-domain.com`. To stay on the temporary
 address, say you do not have a domain. Switching later: tell Codex you want
 the stable hostname; it runs `c2c tunnel choose --mode named --zone <domain>`.
 
@@ -52,16 +56,16 @@ the stable hostname; it runs `c2c tunnel choose --mode named --zone <domain>`.
 Pairing codes are one-time and expire after ~5 minutes:
 
 ```
-c2c pair
+c2c gateway pair
 ```
 
 generates a fresh one (older codes become invalid immediately).
 
 ### ChatGPT gets 401 on every tool call
-The access token expired and refresh failed (e.g. after `c2c unpair` or a
-long offline period). Delete THIS workspace's connector if the address also
-changed; otherwise run Authorize again in ChatGPT and enter a fresh pairing
-code. Never use Reconnect when the public address has been replaced.
+The access token expired and refresh failed (e.g. after a long offline
+period). Re-authorize the single global connector if the address also changed;
+otherwise run Authorize again in ChatGPT and enter a fresh pairing code. Never
+use Reconnect when the public address has been replaced.
 
 ### cloudflared is not installed
 macOS: `brew install cloudflared`
@@ -77,15 +81,15 @@ The C2C state directory lives outside the project (macOS:
 `%LOCALAPPDATA%\codex-with-chatgpt`). Codex's default sandbox cannot write
 there, so each new chat looks like a health-check failure.
 
-`c2c setup`, `c2c doctor` and `c2c sandbox-allow` add that directory to
+`c2c gateway setup`, `c2c gateway doctor` and `c2c sandbox-allow` add that directory to
 `[sandbox_workspace_write].writable_roots` in `~/.codex/config.toml`
 (`%USERPROFILE%\.codex\config.toml` on Windows). After that, later chats
 do not need elevation.
 
 ### Port already in use
-Handled automatically: an existing healthy bridge for the same workspace is
-reused; anything else makes the bridge pick a free port. Configuration follows
-automatically.
+Handled automatically: the shared Gateway is reused and each new workspace is
+attached through a short-lived local lease. A free port is selected when the
+preferred one is occupied.
 
 ### Reading a file returns ACCESS_DENIED_SENSITIVE_FILE
 Working as intended: `.env`, keys, credentials and anything matched by
@@ -100,13 +104,14 @@ collection page is open (`https://chatgpt.com/g/g-p-…/project`).
 ### This workspace opened the wrong ChatGPT Project
 Do not pick another project by name automatically. Open the collection that
 matches this workspace and tell Codex「已找到」, or say you want the old
-long-chat instead. Each workspace has its own Project and its own connector.
+long-chat instead. Projects remain per workspace, but all of them use the
+single shared Gateway connector.
 
 ### Completely stuck
 ```
-c2c stop
-c2c setup
+c2c gateway stop
+c2c gateway setup -w <workspace>
 ```
 
-re-creates the bridge, tunnel and pairing session from scratch. Existing
+re-creates the Gateway, tunnel and pairing session from scratch. Existing
 authorizations stay valid unless you also ran `c2c unpair`.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -14,9 +14,9 @@ ChatGPT thinks. Codex works.
 
 You (Codex) own execution: editing, shell, git, tests, recovery.
 ChatGPT owns high-level reasoning: understanding, planning, review, debug strategy.
-The C2C Bridge gives ChatGPT read-only MCP access to the current workspace, so
-control messages between you and ChatGPT stay tiny (< 1 KB) — ChatGPT pulls
-whatever data it needs by itself.
+The C2C Gateway gives ChatGPT read-only MCP access to the currently attached
+workspace, so control messages between you and ChatGPT stay tiny (< 1 KB) —
+ChatGPT pulls whatever data it needs by itself.
 
 **Golden rules**
 
@@ -27,7 +27,7 @@ whatever data it needs by itself.
    field labels/values the user must enter, without explaining internals.
 3. The pairing code is the ONLY credential you may ever type into a browser.
    Never touch OAuth tokens, cookies, or session storage.
-4. If something fails, run `c2c doctor` and repair silently. Only involve the user
+4. If something fails, run `c2c gateway doctor` and repair silently. Only involve the user
    for logins, CAPTCHA, 2FA, explicit consent screens, or **guided manual
    ChatGPT setup** below — and then give them ONE action.
    Before the first ChatGPT connection on this machine, `c2c prefs --json`:
@@ -69,16 +69,16 @@ whatever data it needs by itself.
      conversation opens a new chat from the Project collection page — never
      `goto` `https://chatgpt.com/` to create it, and never reuse another
      Codex conversation's chat URL just because `session.url` exists.
-   Each workspace also has exactly ONE ChatGPT connector. Do not create a
-   second connector for the same workspace. Other workspaces may have their
-   own connectors — never edit those.
+   The shared Gateway has exactly ONE ChatGPT connector for this machine.
+   Never create a connector per workspace and never edit a connector belonging
+   to another installation.
 7. After first-time setup, never ask the user to approve writing C2C's local
    settings directory. Run `c2c sandbox-allow --json` (idempotent). If it fails
    with EPERM / Operation not permitted, request elevated permissions and retry
    ONCE. After `{ "alreadyAllowed": true }` or `{ "added": true }`, stay silent.
 8. ChatGPT pages: only the URLs in **In-app browser (ChatGPT)**. Never start
    from chatgpt.com and click through menus.
-9. **Doctor gate.** After `c2c doctor --json`, do not `goto` ChatGPT and do not
+9. **Doctor gate.** After `c2c gateway doctor --json`, do not `goto` ChatGPT and do not
    send `[C2C]` until local is green — except the reconnect settings pages when
    `chatgptRepair.needed` is true. Not green:
    - `report.bridge.ok` is not true
@@ -93,6 +93,27 @@ whatever data it needs by itself.
      `chatgptRepair`. Wait and run doctor again.
    A ChatGPT-side 401 after a sent message is different: repair then, do not
    treat it as permission to skip this gate next time.
+
+**Shared Gateway mode (current implementation)**
+
+The connector is global to this machine. There is exactly one connector named
+`Codex with ChatGPT` and one stable MCP URL. A workspace is attached by the
+local Codex process, not by a user-maintained directory list.
+
+- At the start of every workflow, silently run `c2c gateway attach -w <workspace> --json`.
+  This creates or refreshes a short-lived lease and makes that workspace active.
+- For the first setup on a machine, run `c2c gateway setup -w <workspace> --json`.
+  Only that first setup may create/authorize the global connector. Later
+  workspaces must never create, delete, rename, or reconnect a connector.
+- Before sending C2C control messages, run `c2c gateway doctor -w <workspace> --json`.
+  If it is not green, repair the local Gateway first.
+- MCP tools accept an opaque `workspace_id`; never pass a Windows path as a
+  workspace selector. Omit it to use the active lease selected by `attach`.
+  Explicit ids are accepted only for that active lease; switching projects is
+  always a local `attach`/`activate` action.
+- `c2c gateway pair --json` is the only pairing-code refresh command. The old
+  per-workspace `c2c pair`/`c2c setup` flow is legacy and must not be used for a
+  new workspace.
 
 ## In-app browser (ChatGPT)
 
@@ -206,13 +227,15 @@ Inside the checkout directory (see Locations):
 5. Tell the user "✓ 已更新到最新版本" — then resume whatever task triggered this.
    (The updated SKILL.md takes effect from the next Codex session; that's expected.)
 
-## Connection choice (once per workspace)
+## Connection choice (once per Gateway)
 
-Ask this **before** the public address exists (`c2c setup` / first `doctor --fix`
-that starts a tunnel). Do not mention tunnels, wrangler, DNS, or hostnames.
+Ask this **before** the shared public address exists (`c2c gateway setup`). Do
+not repeat it for each new workspace. Do not mention tunnels, wrangler, DNS, or
+hostnames.
 Speak only of 临时地址 / 固定域名 / 登录 Cloudflare.
 
-1. `c2c tunnel status -w <workspace> --json`
+1. `c2c tunnel status -w <workspace> --json` (legacy state may be used only to
+   choose the Gateway's first connection)
 2. If `needsChoice` is false: do not ask again.
 3. If `needsChoice` is true: tell the user exactly `userPrompt` and wait.
    - 没有账号 / 没有域名 / 临时 / 不用 →
@@ -235,14 +258,14 @@ Speak only of 临时地址 / 固定域名 / 登录 Cloudflare.
      `winget install Cloudflare.cloudflared`. Do this yourself; don't ask.
 2. If the c2c repo has no `node_modules`, run `pnpm install && pnpm build` in it.
 3. Run `c2c sandbox-allow --json`, then **Connection choice**, then
-   `c2c setup -w <workspace> --json`.
+   `c2c gateway setup -w <workspace> --json`.
    `sandbox-allow` edits Codex `config.toml` only — it adds C2C's state directory
    to `[sandbox_workspace_write].writable_roots` so later chats can write logs
    without elevation. If the write is denied, request approval and retry once.
-   → returns `{ mcpUrl, pairingCode, workspaceName, connectorName, ... }`.
-   `connectorName` is this workspace's plugin title (legacy installs stay
-   `Codex with ChatGPT`; additional workspaces get `Codex with ChatGPT · <name>`).
-   Pairing codes expire in ~5 minutes: run `c2c pair --json` for a fresh one if you're slow.
+   → returns `{ mcpUrl, pairingCode, workspaceName, connectorName, needsPairing, ... }`.
+   The connector name is always `Codex with ChatGPT`; it is shared by all
+   workspaces. Pairing codes expire in ~5 minutes: run `c2c gateway pair --json`
+   for a fresh one if you're slow.
 4. `c2c prefs --json` (this machine, not this workspace).
    - If `setupMode` is null: tell the user exactly `setupChoicePrompt`. Wait
      for「1」or「2」. Then `c2c prefs set --setup-mode auto` or `--setup-mode manual`.
@@ -257,20 +280,22 @@ Speak only of 临时地址 / 固定域名 / 登录 Cloudflare.
    - `setupMode: "auto"`: continue with step 5. Keep the two-failure fallback.
 5. Open ChatGPT on the ONE iab tab (see **In-app browser**). Foreground +
    markHandoff immediately. Same tab, `goto` only:
+   - If `needsPairing` is false, keep the existing `Codex with ChatGPT`
+     connector unchanged. Do not open connector settings; continue directly to
+     the workspace verification in step 6.
    - 开发人员模式: skip `https://chatgpt.com/#settings/Security` when
      `developerModeEnabled` is true. Otherwise open it, enable 开发人员模式
      ("Developer mode") if it is off, then `c2c prefs set --developer-mode`.
      Never record it as off. If creating the connector later says developer
      mode is required, open this page, enable it, save `--developer-mode`,
      and retry create — do not skip that recovery.
-   - 已有该 `connectorName`: `https://chatgpt.com/plugins` — Delete it (never
-     Reconnect). Then `goto` the 加插件 URL below.
+   - Only when `needsPairing` is true, inspect `https://chatgpt.com/plugins`
+     for the exact global connector name. Do not delete or edit connectors for
+     other installations.
    - 还没有 / 刚删掉: `https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins`
-     Operate ONLY on `connectorName` from step 3:
-      - If that exact name exists: Delete it, then create it again. Never
-        Reconnect, never edit-in-place, never open the old Server URL.
-      - If it does not exist: create one with that exact name.
-      - Never rename, delete, or edit a connector that belongs to another workspace.
+     create the exact global `connectorName` if it does not exist. Never
+     create one for a workspace, reconnect an old per-workspace connector, or
+     edit a connector belonging to another installation.
       - Description: `Securely connect ChatGPT to the current Codex workspace for planning and review.`
       - Server URL: the `mcpUrl` from step 3
       - Authentication: OAuth
@@ -292,7 +317,7 @@ Speak only of 临时地址 / 固定域名 / 登录 Cloudflare.
 Codex with ChatGPT
 
 ✓ 当前项目已识别
-✓ Workspace Bridge 已启动
+✓ 共享 Gateway 已启动
 ✓ 安全连接已建立
 ✓ ChatGPT 已连接
 ✓ 文件读取测试通过
@@ -329,16 +354,18 @@ next action:
    `https://chatgpt.com/#settings/Security` and enable 开发人员模式. After they
    say「好了」, `c2c prefs set --developer-mode`. If it is already remembered,
    skip this step.
-2. Ask them to open `https://chatgpt.com/plugins`. If the exact `connectorName`
-   exists, delete only that connector. Never ask them to touch another workspace's connector.
+2. Ask them to open `https://chatgpt.com/plugins`. If the exact global
+   `connectorName` exists and the address is unchanged, keep it. Never ask
+   them to delete it merely because a new workspace is being attached.
 3. Ask them to open
    `https://chatgpt.com/plugins#settings/Connectors?create-connector=true&redirectAfter=%2Fplugins`
-   and create the exact `connectorName` with:
+   and, only when `needsPairing` is true or the address changed, create the exact
+   global `connectorName` with:
    - Description: `Securely connect ChatGPT to the current Codex workspace for planning and review.`
    - Server URL: the current `mcpUrl`
    - Authentication: OAuth
 4. Ask them to Connect / Authorize and enter the current pairing code. If it
-   expired, run `c2c pair --json` and give them only the fresh pairing code.
+   expired, run `c2c gateway pair --json` and give them only the fresh pairing code.
 5. When they report Connected / authorized / pairing accepted, resume the normal
    setup/reconnect flow at its ChatGPT verification step. If automatic browser
    verification then hits the same explicit failure twice, stop and report the
@@ -493,15 +520,13 @@ Do not invent `STATE: RESUME`. If the original chat is gone, send HANDOFF.
 All control messages start with `[C2C]`. Keep Codex→ChatGPT messages under 1 KB.
 ChatGPT's replies are expected to be substantive (see step 3). Docs: `docs/protocol.md`.
 
-0. `c2c tunnel status -w <workspace> --json`. If `needsChoice`, follow
-   **Connection choice** first (existing installs: ask once, then remember).
-   Then `c2c doctor -w <workspace> --json` (auto-repairs). **Doctor gate:** if local
-   is not green, do not open ChatGPT and do not send INIT. If
-   `namedRepair.needed` is true, tell the user `namedRepair.userMessage`, run
-   `c2c tunnel login --json` (their browser; Cloudflare exception), then doctor
-   again. If `chatgptRepair.needed` is true, tell the user `chatgptRepair.userMessage`
-   (one paragraph, no internals), run **Workflow: reconnect after address
-   reclaim**, then doctor again and only continue when the gate is green.
+0. Run `c2c gateway attach -w <workspace> --json` on every task. This is the
+   automatic current-workspace attach; never ask the user to add a directory.
+   Then run `c2c gateway doctor -w <workspace> --json`. **Doctor gate:** if
+   local is not green, do not open ChatGPT and do not send INIT. If the shared
+   address needs a Cloudflare login, tell the user the one login action and
+   repeat the Gateway doctor. Do not delete or recreate the global connector
+   for a new workspace.
    Generate task id: `c2c_` + 4 random hex chars — unless a checkpoint already
    has one (reuse that id; do not mint a second task).
 1. `c2c session -w <workspace> --json`. Open ChatGPT on the same iab tab
@@ -611,13 +636,28 @@ If status is restricted, ignore it and review from git_diff.
     decision the user must make.
     `c2c session set -w <ws> --protocol-state BLOCKED --waiting-for USER --known-issues "<short reason>"`
 
+## Shared Gateway repair override
+
+The older per-workspace reconnect procedure below is retained for legacy
+installations only. In the current shared Gateway mode, use this shorter path:
+
+1. Run `c2c gateway attach -w <workspace> --json`, then
+   `c2c gateway doctor -w <workspace> --json`.
+2. If the stable hostname is unavailable, ask for the one Cloudflare login and
+   repeat the Gateway doctor. Do not delete the global connector when the
+   hostname is unchanged.
+3. If a temporary address changed, run `c2c gateway pair --json` and
+   re-authorize the single `Codex with ChatGPT` connector with the returned
+   `mcpUrl`; never create a connector named after the workspace.
+4. Verify `workspace_info` in the existing C2C conversation. A new workspace
+   is selected by the next local `gateway attach`, not by connector changes.
+
 ## Workflow: disconnect（"断开 ChatGPT"）
 
-1. `c2c unpair -w <workspace>` (revokes all tokens immediately).
-2. Optionally remove the connector on the same iab tab via
-   `https://chatgpt.com/plugins` (foreground + markHandoff). Only touch
-   this workspace's `connectorName`.
-3. Tell the user: "已断开 ChatGPT 对该项目的访问。"
+1. `c2c gateway unpair` (revokes all shared Gateway tokens immediately).
+2. Optionally remove the single global connector on the same iab tab via
+   `https://chatgpt.com/plugins` (foreground + markHandoff).
+3. Tell the user: "已断开 ChatGPT 对当前机器工作区的访问。"
 
 ## Workflow: reconnect after address reclaim（全关掉以后地址失效）
 

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -14,6 +14,10 @@ export interface BearerAuthDeps {
  * Bearer-token guard for /mcp.
  * - missing/invalid/expired token  -> 401 (+ WWW-Authenticate with resource metadata)
  * - valid token for another workspace -> 403
+ *
+ * A Gateway passes `workspaceId: "*"`. In that mode the token is a global
+ * Gateway credential and the selected workspace is checked by the MCP
+ * resolver against the locally attached workspace leases.
  */
 export function bearerAuth(deps: BearerAuthDeps) {
   return (req: Request, res: Response, next: NextFunction): void => {
@@ -39,7 +43,11 @@ export function bearerAuth(deps: BearerAuthDeps) {
         .json({ error: "unauthorized", error_description: `Token ${verdict.reason}` });
       return;
     }
-    if (verdict.record.workspaceId !== deps.workspaceId) {
+    const workspaceMatches =
+      deps.workspaceId === "*"
+        ? verdict.record.workspaceId === "*"
+        : verdict.record.workspaceId === deps.workspaceId;
+    if (!workspaceMatches) {
       deps.logger.warn("Rejected MCP request: token bound to a different workspace");
       res.status(403).json({
         error: "forbidden",

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -9,7 +9,9 @@ import { escapeHtml, setAuthSecurityHeaders } from "./html.js";
 export interface OAuthDeps {
   store: AuthStore;
   pairing: PairingManager;
-  workspaceName: string;
+  workspaceName: string | (() => string);
+  /** Token binding used by a multi-workspace Gateway ("*" for global). */
+  tokenWorkspaceId?: string;
   getBaseUrl: (req: Request) => string;
   logger: Logger;
 }
@@ -23,6 +25,10 @@ interface PendingAuthRequest {
   codeChallenge: string;
   resource?: string;
   expiresAt: number;
+}
+
+function currentWorkspaceName(value: OAuthDeps["workspaceName"]): string {
+  return typeof value === "function" ? value() : value;
 }
 
 function isAllowedRedirectUri(uri: string): boolean {
@@ -237,7 +243,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
     res
       .status(200)
       .type("html")
-      .send(pairingPage({ requestId: request.id, workspaceName: deps.workspaceName, scopes }));
+      .send(pairingPage({ requestId: request.id, workspaceName: currentWorkspaceName(deps.workspaceName), scopes }));
   });
 
   router.post("/oauth/authorize", urlencoded({ extended: false }), (req, res) => {
@@ -266,7 +272,7 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
         .send(
           pairingPage({
             requestId: request.id,
-            workspaceName: deps.workspaceName,
+            workspaceName: currentWorkspaceName(deps.workspaceName),
             scopes: request.scopes,
             error: messages[verdict.reason] ?? "Verification failed.",
           })
@@ -315,7 +321,11 @@ export function createOAuthRouter(deps: OAuthDeps): Router {
         res.status(400).json({ error: "invalid_grant", error_description: "PKCE verification failed" });
         return;
       }
-      const tokens = deps.store.issueTokens({ clientId, scopes: record.scopes });
+      const tokens = deps.store.issueTokens({
+        clientId,
+        scopes: record.scopes,
+        workspaceId: deps.tokenWorkspaceId,
+      });
       deps.logger.info(`Issued access token for client ${clientId}`);
       res.json({
         access_token: tokens.accessToken,

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -43,9 +43,16 @@ export interface TokenRecord {
   revoked: boolean;
 }
 
-interface PersistedAuthState {
+export interface PersistedAuthState {
   clients: ClientRegistration[];
   tokens: TokenRecord[];
+}
+
+export interface AuthStateMigrationResult {
+  migrated: boolean;
+  sourceFiles: string[];
+  importedClients: number;
+  importedTokens: number;
 }
 
 export type VerifyTokenResult =
@@ -58,6 +65,160 @@ const AUTH_CODE_TTL_MS = 5 * 60 * 1000;
 
 function sha256hex(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+export function authStoreFileFor(workspaceId: string): string {
+  return path.join(ensureDir(path.join(getStateDir(), "auth")), `${workspaceId}.json`);
+}
+
+function migrationMarkerFileFor(targetFile: string): string {
+  const parsed = path.parse(targetFile);
+  return path.join(parsed.dir, `${parsed.name}.migration.json`);
+}
+
+interface AuthStateMigrationMarker {
+  version: 1;
+  migratedAt: string;
+  sourceFiles: string[];
+}
+
+interface EndpointState {
+  workspaceId?: unknown;
+  publicUrl?: unknown;
+  mcpUrl?: unknown;
+}
+
+function endpointUrl(endpoint: EndpointState | null): string | null {
+  if (!endpoint) return null;
+  if (typeof endpoint.mcpUrl === "string" && endpoint.mcpUrl.trim() !== "") return endpoint.mcpUrl;
+  if (typeof endpoint.publicUrl === "string" && endpoint.publicUrl.trim() !== "") return `${endpoint.publicUrl}/mcp`;
+  return null;
+}
+
+function legacyAuthCandidates(targetFile: string): string[] {
+  const authDir = path.dirname(targetFile);
+  let files: string[];
+  try {
+    files = fs
+      .readdirSync(authDir)
+      .filter((name) => name.endsWith(".json") && path.join(authDir, name) !== targetFile)
+      .map((name) => path.join(authDir, name));
+  } catch {
+    return [];
+  }
+
+  // Prefer auth stores belonging to the same stable endpoint. This keeps an
+  // upgrade from importing credentials for unrelated old connectors while
+  // still finding the previous per-workspace store after a Gateway upgrade.
+  const endpointDir = path.join(getStateDir(), "endpoints");
+  const gatewayEndpoint = readJsonIfExists<EndpointState>(path.join(endpointDir, "gateway.json"));
+  const gatewayUrl = endpointUrl(gatewayEndpoint);
+  if (!gatewayUrl) return files;
+
+  const matchingIds = new Set<string>();
+  try {
+    for (const name of fs.readdirSync(endpointDir)) {
+      if (!name.endsWith(".json") || name === "gateway.json") continue;
+      const endpoint = readJsonIfExists<EndpointState>(path.join(endpointDir, name));
+      if (endpointUrl(endpoint) !== gatewayUrl) continue;
+      const id = typeof endpoint?.workspaceId === "string" ? endpoint.workspaceId : path.basename(name, ".json");
+      matchingIds.add(id);
+    }
+  } catch {
+    // If endpoint state is unavailable, the caller can still recover by
+    // considering all legacy auth files in this local state directory.
+  }
+  const linked = files.filter((file) => matchingIds.has(path.basename(file, ".json")));
+  return linked.length > 0 ? linked : files;
+}
+
+/**
+ * Import the previous per-workspace OAuth state into the shared Gateway.
+ *
+ * Only persisted hashes are copied; plaintext access/refresh tokens are never
+ * reconstructed or logged. Imported records are rebound to `targetWorkspaceId`
+ * so an existing ChatGPT authorization can keep using the stable connector.
+ * A marker makes the upgrade one-shot, including after the user later revokes
+ * all Gateway tokens.
+ */
+export function migrateLegacyAuthState(opts: {
+  targetFile: string;
+  targetWorkspaceId?: string;
+}): AuthStateMigrationResult {
+  const targetWorkspaceId = opts.targetWorkspaceId ?? "*";
+  const markerFile = migrationMarkerFileFor(opts.targetFile);
+  if (readJsonIfExists<AuthStateMigrationMarker>(markerFile)?.version === 1) {
+    return { migrated: false, sourceFiles: [], importedClients: 0, importedTokens: 0 };
+  }
+
+  const target = readJsonIfExists<PersistedAuthState>(opts.targetFile);
+  if ((target?.tokens ?? []).some((token) => !token.revoked && token.expiresAt > Date.now())) {
+    // A Gateway that already has a live credential has either completed this
+    // migration or was paired directly. Do not resurrect an old credential
+    // after a later `unpair`.
+    writeSecureJson(markerFile, {
+      version: 1,
+      migratedAt: new Date().toISOString(),
+      sourceFiles: [],
+    } satisfies AuthStateMigrationMarker);
+    return { migrated: false, sourceFiles: [], importedClients: 0, importedTokens: 0 };
+  }
+
+  const sources = legacyAuthCandidates(opts.targetFile);
+  const clients = new Map<string, ClientRegistration>();
+  const tokens = new Map<string, TokenRecord>();
+  for (const client of target?.clients ?? []) {
+    if (client && typeof client.clientId === "string") clients.set(client.clientId, client);
+  }
+  for (const token of target?.tokens ?? []) {
+    if (token && typeof token.hash === "string") tokens.set(token.hash, token);
+  }
+
+  const importedSources: string[] = [];
+  let importedClientIds = new Set<string>();
+  let importedTokenHashes = new Set<string>();
+  for (const sourceFile of sources) {
+    const source = readJsonIfExists<PersistedAuthState>(sourceFile);
+    if (!source || !Array.isArray(source.tokens) || source.tokens.length === 0) continue;
+    let importedFromSource = false;
+    for (const client of source.clients ?? []) {
+      if (client && typeof client.clientId === "string") {
+        clients.set(client.clientId, client);
+        importedClientIds.add(client.clientId);
+        importedFromSource = true;
+      }
+    }
+    for (const token of source.tokens) {
+      if (
+        !token ||
+        typeof token.hash !== "string" ||
+        (token.kind !== "access" && token.kind !== "refresh") ||
+        token.revoked ||
+        token.expiresAt <= Date.now()
+      ) {
+        continue;
+      }
+      tokens.set(token.hash, { ...token, workspaceId: targetWorkspaceId });
+      importedTokenHashes.add(token.hash);
+      importedFromSource = true;
+    }
+    if (importedFromSource) importedSources.push(sourceFile);
+  }
+
+  if (importedSources.length === 0) return { migrated: false, sourceFiles: [], importedClients: 0, importedTokens: 0 };
+
+  writeSecureJson(opts.targetFile, { clients: [...clients.values()], tokens: [...tokens.values()] });
+  writeSecureJson(markerFile, {
+    version: 1,
+    migratedAt: new Date().toISOString(),
+    sourceFiles: importedSources,
+  } satisfies AuthStateMigrationMarker);
+  return {
+    migrated: true,
+    sourceFiles: importedSources,
+    importedClients: [...importedClientIds].filter((id) => !(target?.clients ?? []).some((client) => client.clientId === id)).length,
+    importedTokens: [...importedTokenHashes].filter((hash) => !(target?.tokens ?? []).some((token) => token.hash === hash)).length,
+  };
 }
 
 function newToken(prefix: string): string {
@@ -86,8 +247,7 @@ export class AuthStore {
     readonly workspaceId: string,
     opts: { file?: string } = {}
   ) {
-    this.file =
-      opts.file ?? path.join(ensureDir(path.join(getStateDir(), "auth")), `${workspaceId}.json`);
+    this.file = opts.file ?? authStoreFileFor(workspaceId);
     this.load();
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,8 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { startBridge } from "../bridge/server.js";
 import { findBridgeObservation, findLiveBridge, type RuntimeState } from "../bridge/runtime.js";
-import { adminFetch, ensureBridge, stopBridge } from "../process/daemon.js";
+import { GATEWAY_ID, findLiveGateway, type GatewayRuntimeState } from "../gateway/runtime.js";
+import { adminFetch, ensureBridge, ensureGateway, gatewayAdminFetch, stopBridge, stopGateway } from "../process/daemon.js";
 import { Workspace } from "../workspace/manager.js";
 import { AuthStore } from "../auth/store.js";
 import { detectTunnelBinaries } from "../tunnel/detect.js";
@@ -23,6 +24,7 @@ import {
   needsTunnelChoice,
   readTunnelState,
   TUNNEL_CHOICE_PROMPT,
+  writeTunnelState,
 } from "../tunnel/state.js";
 import { Logger } from "../logger/index.js";
 import { getStateDir } from "../config/paths.js";
@@ -189,6 +191,29 @@ interface AdminInfo {
   startedAt: string;
 }
 
+interface GatewayAdminInfo {
+  service: string;
+  version: string;
+  gatewayId: string;
+  workspaceId: string | null;
+  workspaceName: string | null;
+  workspaces: Array<{
+    workspaceId: string;
+    workspaceRoot: string;
+    workspaceName: string;
+    attachedAt: string;
+    lastSeenAt: string;
+    expiresAt: number;
+  }>;
+  port: number;
+  publicUrl: string | null;
+  tunnel: { running: boolean; url: string | null; provider: string };
+  tokenCount: number;
+  pairingActive: boolean;
+  pid: number;
+  startedAt: string;
+}
+
 async function ensureBridgeAndTunnel(
   workspaceRoot: string,
   opts: { tunnel: boolean }
@@ -211,6 +236,40 @@ async function ensureBridgeAndTunnel(
   return { runtime, info, mcpUrl };
 }
 
+async function ensureGatewayAndTunnel(
+  workspaceRoot: string,
+  opts: { tunnel: boolean }
+): Promise<{ runtime: GatewayRuntimeState; info: GatewayAdminInfo; mcpUrl: string | null; attached: Record<string, unknown> }> {
+  // Preserve a previously provisioned per-workspace named tunnel when this
+  // installation is upgraded to the shared Gateway. The hostname remains the
+  // user's stable endpoint; only its local state key changes to `gateway`.
+  const workspace = new Workspace(workspaceRoot);
+  const gatewayTunnel = readTunnelState(GATEWAY_ID);
+  const legacyTunnel = readTunnelState(workspace.id);
+  if (!isNamedTunnelReady(gatewayTunnel) && isNamedTunnelReady(legacyTunnel)) {
+    writeTunnelState({ ...legacyTunnel, workspaceId: GATEWAY_ID });
+  }
+  const { runtime } = await ensureGateway(workspaceRoot);
+  const attached = await gatewayAdminFetch<Record<string, unknown>>(runtime, "POST", "/admin/attach", {
+    workspaceRoot: path.resolve(workspaceRoot),
+  });
+  let info = await gatewayAdminFetch<GatewayAdminInfo>(runtime, "GET", "/admin/info");
+  let mcpUrl: string | null = info.publicUrl ? `${info.publicUrl}/mcp` : null;
+  if (opts.tunnel && !info.publicUrl) {
+    const binaries = detectTunnelBinaries();
+    if (!binaries.cloudflared) {
+      throw new Error(
+        "NEED_CLOUDFLARED: cloudflared is not installed. Install it first (Windows: winget install Cloudflare.cloudflared)."
+      );
+    }
+    const result = await gatewayAdminFetch<TunnelStartResponse>(runtime, "POST", "/admin/tunnel/start", undefined, 90_000);
+    if (!result.url) throw new Error(result.message ?? "Tunnel start failed");
+    info = await gatewayAdminFetch<GatewayAdminInfo>(runtime, "GET", "/admin/info");
+    mcpUrl = `${result.url}/mcp`;
+  }
+  return { runtime, info, mcpUrl, attached };
+}
+
 program
   .name("c2c")
   .description(`${PRODUCT_NAME} — ChatGPT thinks. Codex works.`)
@@ -224,8 +283,24 @@ program
   .description("Run the bridge in the foreground (internal)")
   .requiredOption("--workspace <path>")
   .option("--port <port>", "preferred port")
-  .action(async (opts: { workspace: string; port?: string }) => {
+  .option("--gateway", "run the multi-workspace Gateway", false)
+  .action(async (opts: { workspace: string; port?: string; gateway: boolean }) => {
     const logger = new Logger({ name: "bridge", console: true });
+    if (opts.gateway) {
+      const { startGateway } = await import("../gateway/server.js");
+      const gateway = await startGateway({
+        workspaceRoot: resolveWorkspace(opts.workspace),
+        port: opts.port ? parseInt(opts.port, 10) : undefined,
+        logger,
+      });
+      const shutdown = (): void => {
+        void gateway.close().then(() => process.exit(0));
+      };
+      process.on("SIGINT", shutdown);
+      process.on("SIGTERM", shutdown);
+      say(`gateway ready on ${gateway.localBaseUrl()}`);
+      return;
+    }
     const bridge = await startBridge({
       workspaceRoot: resolveWorkspace(opts.workspace),
       port: opts.port ? parseInt(opts.port, 10) : undefined,
@@ -239,44 +314,224 @@ program
     say(`bridge ready on ${bridge.localBaseUrl()} (workspace ${bridge.workspace.name})`);
   });
 
-// ---------------------------------------------------------------- start
+// ---------------------------------------------------------------- gateway (single endpoint, automatic workspace attachment)
+
+const gatewayCmd = program
+  .command("gateway")
+  .description("Use one MCP Gateway for all Codex workspaces");
+
+function gatewayConnectorName(): string {
+  return PRODUCT_NAME;
+}
+
+function persistGatewayEndpoint(info: GatewayAdminInfo, mcpUrl: string): void {
+  writeLastEndpoint({
+    workspaceId: GATEWAY_ID,
+    port: info.port,
+    publicUrl: info.publicUrl,
+    mcpUrl,
+    connectorName: gatewayConnectorName(),
+  });
+}
+
+gatewayCmd
+  .command("setup")
+  .description("Start the shared Gateway and return the one-time connector details")
+  .option("-w, --workspace <path>")
+  .option("--no-tunnel", "local-only setup (development)")
+  .option("--json", "machine-readable output", false)
+  .action(async (opts: { workspace?: string; tunnel: boolean; json: boolean }) => {
+    const root = resolveWorkspace(opts.workspace);
+    try {
+      const { runtime, info, mcpUrl } = await ensureGatewayAndTunnel(root, { tunnel: opts.tunnel });
+      const endpoint = mcpUrl ?? `http://127.0.0.1:${runtime.port}/mcp`;
+      if (mcpUrl) persistGatewayEndpoint(info, mcpUrl);
+      const pairing = info.tokenCount === 0
+        ? await gatewayAdminFetch<PairingResponse>(runtime, "POST", "/admin/pairing")
+        : null;
+      if (opts.json) {
+        say(JSON.stringify({
+          ok: true,
+          gateway: true,
+          gatewayId: GATEWAY_ID,
+          workspaceId: info.workspaceId,
+          workspaceName: info.workspaceName,
+          connectorName: gatewayConnectorName(),
+          mcpUrl: endpoint,
+          local: mcpUrl === null,
+          pairingCode: pairing?.code ?? null,
+          pairingExpiresAt: pairing?.expiresAt ?? null,
+          needsPairing: pairing !== null,
+          workspaces: info.workspaces,
+        }));
+        return;
+      }
+      check(`当前项目已自动附加（${info.workspaceName ?? "未命名"}）`);
+      check("共享 Gateway 已启动");
+      say(`连接地址：${endpoint}`);
+      if (pairing) say(`首次配对码：${pairing.code}`);
+      else check("ChatGPT 连接已复用，新项目无需重新授权");
+    } catch (error) {
+      handleCliError(error, opts.json);
+    }
+  });
+
+gatewayCmd
+  .command("attach")
+  .description("Automatically attach the current workspace to the shared Gateway")
+  .option("-w, --workspace <path>")
+  .option("--json", "machine-readable output", false)
+  .action(async (opts: { workspace?: string; json: boolean }) => {
+    const root = resolveWorkspace(opts.workspace);
+    try {
+      const { runtime, info, mcpUrl, attached } = await ensureGatewayAndTunnel(root, { tunnel: false });
+      const endpoint = mcpUrl ?? (info.publicUrl ? `${info.publicUrl}/mcp` : `http://127.0.0.1:${runtime.port}/mcp`);
+      if (info.publicUrl) persistGatewayEndpoint(info, `${info.publicUrl}/mcp`);
+      const payload = {
+        ok: true,
+        gateway: true,
+        gatewayId: GATEWAY_ID,
+        workspaceId: info.workspaceId,
+        workspaceName: info.workspaceName,
+        workspaceRoot: root,
+        leaseExpiresAt: (attached.leaseExpiresAt as number | undefined) ?? null,
+        connectorName: gatewayConnectorName(),
+        mcpUrl: endpoint,
+        needsPairing: info.tokenCount === 0,
+      };
+      if (opts.json) say(JSON.stringify(payload));
+      else check(`已自动附加当前项目（${info.workspaceName ?? "未命名"}）`);
+    } catch (error) {
+      handleCliError(error, opts.json);
+    }
+  });
+
+gatewayCmd
+  .command("status")
+  .description("Show the shared Gateway and attached workspace leases")
+  .option("--json", "machine-readable output", false)
+  .action(async (opts: { json: boolean }) => {
+    try {
+      const runtime = await findLiveGateway();
+      if (!runtime) {
+        const payload = { ok: false, running: false, gateway: true };
+        if (opts.json) say(JSON.stringify(payload));
+        else say("共享 Gateway 未运行。");
+        return;
+      }
+      const info = await gatewayAdminFetch<GatewayAdminInfo>(runtime, "GET", "/admin/info");
+      if (opts.json) say(JSON.stringify({ ok: true, running: true, gateway: true, ...info }));
+      else {
+        check(`共享 Gateway 运行中（端口 ${info.port}）`);
+        check(`当前项目：${info.workspaceName ?? "未选择"}`);
+        say(`已附加项目数：${info.workspaces.length}`);
+      }
+    } catch (error) {
+      handleCliError(error, opts.json);
+    }
+  });
+
+gatewayCmd
+  .command("pair")
+  .description("Generate a one-time pairing code for the shared connector")
+  .option("--json", "machine-readable output", false)
+  .action(async (opts: { json: boolean }) => {
+    try {
+      const runtime = await findLiveGateway();
+      if (!runtime) throw new Error("Gateway 未运行，请先执行 c2c gateway setup");
+      const pairing = await gatewayAdminFetch<PairingResponse>(runtime, "POST", "/admin/pairing");
+      if (opts.json) say(JSON.stringify({ ok: true, pairingCode: pairing.code, expiresAt: pairing.expiresAt }));
+      else say(`配对码：${pairing.code}`);
+    } catch (error) {
+      handleCliError(error, opts.json);
+    }
+  });
+
+gatewayCmd
+  .command("unpair")
+  .description("Revoke the shared Gateway OAuth credentials")
+  .option("--json", "machine-readable output", false)
+  .action(async (opts: { json: boolean }) => {
+    try {
+      const runtime = await findLiveGateway();
+      if (!runtime) throw new Error("Gateway 未运行，请先执行 c2c gateway setup");
+      const result = await gatewayAdminFetch<{ revoked: number }>(runtime, "POST", "/admin/revoke-all");
+      if (opts.json) say(JSON.stringify({ ok: true, revoked: result.revoked }));
+      else check(`已撤销共享 Gateway 授权（${result.revoked} 个令牌）`);
+    } catch (error) {
+      handleCliError(error, opts.json);
+    }
+  });
+
+gatewayCmd
+  .command("doctor")
+  .description("Check the shared Gateway after automatically attaching the current workspace")
+  .option("-w, --workspace <path>")
+  .option("--json", "machine-readable output", false)
+  .action(async (opts: { workspace?: string; json: boolean }) => {
+    const root = resolveWorkspace(opts.workspace);
+    try {
+      const { runtime, info, mcpUrl } = await ensureGatewayAndTunnel(root, { tunnel: false });
+      const response = await fetch(`http://127.0.0.1:${runtime.port}/mcp`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 }),
+      });
+      const report = {
+        ok: response.status === 401,
+        gateway: { ok: true, port: runtime.port, activeWorkspaceId: info.workspaceId },
+        mcp: { ok: response.status === 401, status: response.status },
+        workspace: { ok: info.workspaceId !== null, workspaceId: info.workspaceId, workspaceName: info.workspaceName },
+        connector: { name: gatewayConnectorName(), mcpUrl: mcpUrl ?? (info.publicUrl ? `${info.publicUrl}/mcp` : null) },
+      };
+      if (opts.json) say(JSON.stringify(report));
+      else if (report.ok) check(`共享 Gateway 正常，当前项目已附加（${info.workspaceName ?? "未命名"}）`);
+      else cross(`共享 Gateway 检查失败（MCP 返回 ${response.status}）`);
+      if (!report.ok) process.exitCode = 1;
+    } catch (error) {
+      handleCliError(error, opts.json);
+    }
+  });
+
+gatewayCmd
+  .command("stop")
+  .description("Stop the shared Gateway")
+  .action(async () => {
+    if (await stopGateway()) check("共享 Gateway 已停止");
+    else say("共享 Gateway 未运行。");
+  });
+
+// ---------------------------------------------------------------- start (shared Gateway compatibility alias)
 
 program
   .command("start")
-  .description("Start (or reuse) the bridge for this workspace")
+  .description("Start (or reuse) the shared Gateway and attach this workspace")
   .option("-w, --workspace <path>", "workspace root (defaults to current directory)")
   .option("--tunnel", "also establish the secure public connection", false)
   .option("--json", "machine-readable output", false)
   .action(async (opts: { workspace?: string; tunnel: boolean; json: boolean }) => {
     const root = resolveWorkspace(opts.workspace);
     try {
-      const { runtime, info, mcpUrl } = await ensureBridgeAndTunnel(root, { tunnel: opts.tunnel });
-      const connectorName = mcpUrl
-        ? persistWorkspaceEndpoint({
-            workspaceId: info.workspaceId,
-            workspaceName: info.workspaceName,
-            port: runtime.port,
-            publicUrl: info.publicUrl,
-            mcpUrl,
-          })
-        : readLastEndpoint(info.workspaceId)?.connectorName;
+      const { runtime, info, mcpUrl } = await ensureGatewayAndTunnel(root, { tunnel: opts.tunnel });
+      if (mcpUrl) persistGatewayEndpoint(info, mcpUrl);
+      const connectorName = gatewayConnectorName();
       if (opts.json) {
-        say(JSON.stringify({ ok: true, port: runtime.port, workspaceId: info.workspaceId, mcpUrl, connectorName }));
+        say(JSON.stringify({ ok: true, gateway: true, port: runtime.port, workspaceId: info.workspaceId, mcpUrl, connectorName }));
         return;
       }
       check(`当前项目已识别（${info.workspaceName}）`);
-      check("Workspace Bridge 已启动");
+      check("共享 Gateway 已启动");
       if (mcpUrl) check("安全连接已建立");
     } catch (error) {
       handleCliError(error, opts.json);
     }
   });
 
-// ---------------------------------------------------------------- setup
+// ---------------------------------------------------------------- setup (shared Gateway compatibility alias)
 
 program
   .command("setup")
-  .description("First-time setup: bridge + secure connection + pairing code")
+  .description("First-time setup: shared Gateway + secure connection + pairing code")
   .option("-w, --workspace <path>")
   .option("--no-tunnel", "local-only setup (development)")
   .option("--json", "machine-readable output", false)
@@ -290,23 +545,13 @@ program
         say("");
       }
       const sandbox = trySandboxAllow();
-      const { runtime, info, mcpUrl } = await ensureBridgeAndTunnel(root, { tunnel: opts.tunnel });
-      const connectorName = mcpUrl
-        ? persistWorkspaceEndpoint({
-            workspaceId: info.workspaceId,
-            workspaceName: info.workspaceName,
-            port: runtime.port,
-            publicUrl: info.publicUrl,
-            mcpUrl,
-          })
-        : connectorNameFor({
-            workspaceName: info.workspaceName,
-            workspaceId: info.workspaceId,
-            previousName: readLastEndpoint(info.workspaceId)?.connectorName,
-            hadEndpointBefore: Boolean(readLastEndpoint(info.workspaceId)),
-          });
-      const pairingResult = await adminFetch<PairingResponse>(runtime, "POST", "/admin/pairing");
-      const tunnelState = readTunnelState(info.workspaceId);
+      const { runtime, info, mcpUrl } = await ensureGatewayAndTunnel(root, { tunnel: opts.tunnel });
+      if (mcpUrl) persistGatewayEndpoint(info, mcpUrl);
+      const connectorName = gatewayConnectorName();
+      const pairingResult = info.tokenCount === 0
+        ? await gatewayAdminFetch<PairingResponse>(runtime, "POST", "/admin/pairing")
+        : null;
+      const tunnelState = readTunnelState(GATEWAY_ID);
       if (opts.json) {
         say(
           JSON.stringify({
@@ -314,10 +559,12 @@ program
             workspaceId: info.workspaceId,
             workspaceName: info.workspaceName,
             connectorName,
+            gateway: true,
             mcpUrl: mcpUrl ?? `http://127.0.0.1:${runtime.port}/mcp`,
             local: mcpUrl === null,
-            pairingCode: pairingResult.code,
-            pairingExpiresAt: pairingResult.expiresAt,
+            pairingCode: pairingResult?.code ?? null,
+            pairingExpiresAt: pairingResult?.expiresAt ?? null,
+            needsPairing: pairingResult !== null,
             sandbox,
             tunnel: {
               mode: isNamedTunnelReady(tunnelState) ? "named" : "quick",
@@ -329,13 +576,14 @@ program
         return;
       }
       check(`当前项目已识别（${info.workspaceName}）`);
-      check("Workspace Bridge 已启动");
+      check("共享 Gateway 已启动");
       if (mcpUrl) check("安全连接已建立");
       say("");
       say(`连接地址：${mcpUrl ?? `http://127.0.0.1:${runtime.port}/mcp`}`);
-      say(`配对码：${pairingResult.code}（${Math.round((pairingResult.expiresAt - Date.now()) / 60000)} 分钟内有效）`);
+      if (pairingResult) say(`首次配对码：${pairingResult.code}（${Math.round((pairingResult.expiresAt - Date.now()) / 60000)} 分钟内有效）`);
       say("");
-      say("下一步：在 ChatGPT 的连接器设置中添加以上地址（OAuth），并在授权页输入配对码。");
+      if (pairingResult) say("下一步：在 ChatGPT 的连接器设置中添加一次以上地址（OAuth），并在授权页输入配对码。");
+      else say("ChatGPT 连接已复用，新工作区无需再次授权。");
       say("如果你在使用 Codex Skill，这一步会自动完成。");
     } catch (error) {
       handleCliError(error, opts.json);
@@ -346,26 +594,26 @@ program
 
 program
   .command("stop")
-  .description("Stop the bridge for this workspace")
+  .description("Stop the shared Gateway")
   .option("-w, --workspace <path>")
   .action(async (opts: { workspace?: string }) => {
-    const stopped = await stopBridge(resolveWorkspace(opts.workspace));
-    if (stopped) check("Bridge 已停止");
-    else say("没有正在运行的 Bridge。");
+    const stopped = await stopGateway();
+    if (stopped) check("共享 Gateway 已停止");
+    else say("共享 Gateway 未运行。");
   });
 
 program
   .command("restart")
-  .description("Restart the bridge for this workspace")
+  .description("Restart the shared Gateway and attach this workspace")
   .option("-w, --workspace <path>")
   .option("--tunnel", "re-establish the secure public connection", false)
   .action(async (opts: { workspace?: string; tunnel: boolean }) => {
     const root = resolveWorkspace(opts.workspace);
-    await stopBridge(root);
+    await stopGateway();
     await new Promise((resolve) => setTimeout(resolve, 500));
     try {
-      const { info, mcpUrl } = await ensureBridgeAndTunnel(root, { tunnel: opts.tunnel });
-      check(`Bridge 已重启（${info.workspaceName}）`);
+      const { info, mcpUrl } = await ensureGatewayAndTunnel(root, { tunnel: opts.tunnel });
+      check(`共享 Gateway 已重启（${info.workspaceName}）`);
       if (mcpUrl) check(`安全连接已建立`);
     } catch (error) {
       handleCliError(error, false);
@@ -376,39 +624,33 @@ program
 
 program
   .command("status")
-  .description("Show bridge status for this workspace")
+  .description("Show shared Gateway status and attached workspaces")
   .option("-w, --workspace <path>")
   .option("--json", "machine-readable output", false)
   .action(async (opts: { workspace?: string; json: boolean }) => {
-    const root = resolveWorkspace(opts.workspace);
-    const workspace = new Workspace(root);
-    const observation = await findBridgeObservation(workspace.id);
-    if (observation.state === "unknown") {
-      if (opts.json) {
-        say(JSON.stringify({ ok: false, running: null, state: "unknown", reason: observation.reason }));
-      } else {
-        cross(`Bridge 状态无法确认（${observation.reason}），未将其视为未运行。`);
+    try {
+      const runtime = await findLiveGateway();
+      if (!runtime) {
+        if (opts.json) say(JSON.stringify({ ok: false, running: false, gateway: true }));
+        else say("共享 Gateway 未运行。使用 `c2c gateway setup` 启动。");
+        return;
       }
-      return;
+      const info = await gatewayAdminFetch<GatewayAdminInfo>(runtime, "GET", "/admin/info");
+      if (opts.json) {
+        say(JSON.stringify({ ok: true, running: true, gateway: true, ...info }));
+        return;
+      }
+      say(PRODUCT_NAME);
+      say("");
+      check(`共享 Gateway：运行中（端口 ${info.port}）`);
+      check(`当前项目：${info.workspaceName ?? "未选择"}`);
+      say(`已附加项目数：${info.workspaces.length}`);
+      if (info.tunnel.running && info.tunnel.url) check(`安全连接：${info.tunnel.url}/mcp`);
+      else say("· 安全连接：未启用（本地模式）");
+      say(`· 已授权连接：${info.tokenCount > 0 ? "是" : "否"}`);
+    } catch (error) {
+      handleCliError(error, opts.json);
     }
-    if (observation.state === "stopped") {
-      if (opts.json) say(JSON.stringify({ ok: false, running: false }));
-      else say("Bridge 未运行。使用 `c2c start` 启动。");
-      return;
-    }
-    const runtime = observation.runtime;
-    const info = await adminFetch<AdminInfo>(runtime, "GET", "/admin/info");
-    if (opts.json) {
-      say(JSON.stringify({ ok: true, running: true, ...info }));
-      return;
-    }
-    say(PRODUCT_NAME);
-    say("");
-    check(`Workspace：${info.workspaceName}`);
-    check(`Bridge：运行中（端口 ${info.port}）`);
-    if (info.tunnel.running && info.tunnel.url) check(`安全连接：${info.tunnel.url}/mcp`);
-    else say("· 安全连接：未启用（本地模式）");
-    say(`· 已授权连接：${info.tokenCount > 0 ? "是" : "否"}`);
   });
 
 // ---------------------------------------------------------------- doctor

--- a/src/gateway/registry.ts
+++ b/src/gateway/registry.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir, getStateDir, readJsonIfExists, writeSecureJson } from "../config/paths.js";
+import { Workspace } from "../workspace/manager.js";
+
+/**
+ * A workspace lease is created by the local Codex process when it starts work
+ * in a directory. The public MCP endpoint can only resolve leased workspaces;
+ * it never accepts a filesystem path from a remote caller.
+ */
+export interface WorkspaceLease {
+  workspaceId: string;
+  workspaceRoot: string;
+  workspaceName: string;
+  attachedAt: string;
+  lastSeenAt: string;
+  expiresAt: number;
+}
+
+interface PersistedRegistry {
+  leases: WorkspaceLease[];
+  activeWorkspaceId?: string;
+}
+
+export class GatewayWorkspaceError extends Error {
+  constructor(
+    public code:
+      | "WORKSPACE_NOT_ATTACHED"
+      | "NO_ACTIVE_WORKSPACE"
+      | "WORKSPACE_EXPIRED"
+      | "WORKSPACE_NOT_ACTIVE",
+    message: string
+  ) {
+    super(message);
+    this.name = "GatewayWorkspaceError";
+  }
+}
+
+const DEFAULT_LEASE_TTL_MS = 30 * 60 * 1000;
+
+function registryFile(): string {
+  return path.join(ensureDir(path.join(getStateDir(), "gateway")), "workspaces.json");
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * In-memory workspace map with an automatically refreshed, short-lived lease.
+ * Persisting the lease is useful for diagnostics and process handoff, but
+ * expired leases are discarded on load so a restart never grants stale access.
+ */
+export class WorkspaceRegistry {
+  private readonly leases = new Map<string, WorkspaceLease>();
+  private readonly workspaces = new Map<string, Workspace>();
+  private activeWorkspaceId: string | null = null;
+  private readonly file: string;
+  private readonly leaseTtlMs: number;
+
+  constructor(opts: { file?: string; leaseTtlMs?: number } = {}) {
+    this.file = opts.file ?? registryFile();
+    this.leaseTtlMs = Math.max(60_000, opts.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS);
+    this.load();
+  }
+
+  private load(): void {
+    const state = readJsonIfExists<PersistedRegistry>(this.file);
+    if (!state) return;
+    const now = Date.now();
+    for (const lease of state.leases ?? []) {
+      if (!lease || typeof lease.workspaceId !== "string" || lease.expiresAt <= now) continue;
+      // Do not eagerly instantiate or trust a persisted path. A local attach
+      // refreshes the lease and validates the root before it becomes usable.
+      this.leases.set(lease.workspaceId, lease);
+    }
+    if (state.activeWorkspaceId && this.leases.has(state.activeWorkspaceId)) {
+      this.activeWorkspaceId = state.activeWorkspaceId;
+    }
+    this.prune(false);
+  }
+
+  private save(): void {
+    this.prune(false);
+    const state: PersistedRegistry = {
+      leases: [...this.leases.values()],
+      activeWorkspaceId: this.activeWorkspaceId ?? undefined,
+    };
+    writeSecureJson(this.file, state);
+  }
+
+  private prune(save = true): void {
+    const now = Date.now();
+    let changed = false;
+    for (const [id, lease] of this.leases) {
+      if (lease.expiresAt <= now) {
+        this.leases.delete(id);
+        this.workspaces.delete(id);
+        changed = true;
+      }
+    }
+    if (this.activeWorkspaceId && !this.leases.has(this.activeWorkspaceId)) {
+      this.activeWorkspaceId = null;
+      changed = true;
+    }
+    if (changed && save) this.save();
+  }
+
+  /** Attach or refresh the workspace selected by the local Codex process. */
+  attach(rootInput: string): { workspace: Workspace; lease: WorkspaceLease; created: boolean } {
+    const workspace = new Workspace(rootInput);
+    const previous = this.leases.get(workspace.id);
+    const now = Date.now();
+    const lease: WorkspaceLease = {
+      workspaceId: workspace.id,
+      workspaceRoot: workspace.root,
+      workspaceName: workspace.name,
+      attachedAt: previous?.attachedAt ?? nowIso(),
+      lastSeenAt: nowIso(),
+      expiresAt: now + this.leaseTtlMs,
+    };
+    this.leases.set(workspace.id, lease);
+    this.workspaces.set(workspace.id, workspace);
+    this.activeWorkspaceId = workspace.id;
+    this.save();
+    return { workspace, lease, created: !previous };
+  }
+
+  /** Refresh a lease only after the root has been attached locally. */
+  touch(workspaceId: string): Workspace {
+    const workspace = this.resolve(workspaceId);
+    const lease = this.leases.get(workspaceId);
+    if (lease) {
+      lease.lastSeenAt = nowIso();
+      lease.expiresAt = Date.now() + this.leaseTtlMs;
+      this.save();
+    }
+    return workspace;
+  }
+
+  resolve(workspaceId?: string): Workspace {
+    this.prune();
+    const requestedId = workspaceId?.trim();
+    const id = requestedId || this.activeWorkspaceId;
+    if (!id) throw new GatewayWorkspaceError("NO_ACTIVE_WORKSPACE", "No active workspace is attached.");
+    const lease = this.leases.get(id);
+    if (!lease) {
+      throw new GatewayWorkspaceError("WORKSPACE_NOT_ATTACHED", "The requested workspace is not attached.");
+    }
+    if (requestedId && requestedId !== this.activeWorkspaceId) {
+      throw new GatewayWorkspaceError(
+        "WORKSPACE_NOT_ACTIVE",
+        "The requested workspace is attached but not active; attach or activate it locally first."
+      );
+    }
+    if (lease.expiresAt <= Date.now()) {
+      this.leases.delete(id);
+      this.workspaces.delete(id);
+      if (this.activeWorkspaceId === id) this.activeWorkspaceId = null;
+      this.save();
+      throw new GatewayWorkspaceError("WORKSPACE_EXPIRED", "The workspace lease has expired; attach it again.");
+    }
+    const workspace = this.workspaces.get(id);
+    if (!workspace) {
+      throw new GatewayWorkspaceError("WORKSPACE_NOT_ATTACHED", "The workspace must be re-attached after the Gateway restarted.");
+    }
+    // An MCP call is proof that the local context is still in use. Refresh the
+    // lease so long-running reviews do not expire midway through a task.
+    lease.lastSeenAt = nowIso();
+    lease.expiresAt = Date.now() + this.leaseTtlMs;
+    this.save();
+    return workspace;
+  }
+
+  setActive(workspaceId: string): Workspace {
+    this.prune();
+    const lease = this.leases.get(workspaceId);
+    const workspace = lease ? this.workspaces.get(workspaceId) : undefined;
+    if (!lease || !workspace) {
+      throw new GatewayWorkspaceError("WORKSPACE_NOT_ATTACHED", "The requested workspace is not attached.");
+    }
+    this.activeWorkspaceId = workspaceId;
+    lease.lastSeenAt = nowIso();
+    lease.expiresAt = Date.now() + this.leaseTtlMs;
+    this.save();
+    return workspace;
+  }
+
+  active(): Workspace {
+    return this.resolve();
+  }
+
+  list(): WorkspaceLease[] {
+    this.prune();
+    return [...this.leases.values()].map((lease) => ({ ...lease }));
+  }
+
+  getActiveId(): string | null {
+    this.prune();
+    return this.activeWorkspaceId;
+  }
+
+  detach(workspaceId: string): boolean {
+    const existed = this.leases.delete(workspaceId);
+    this.workspaces.delete(workspaceId);
+    if (this.activeWorkspaceId === workspaceId) {
+      const next = [...this.leases.keys()].at(-1) ?? null;
+      this.activeWorkspaceId = next;
+    }
+    if (existed) this.save();
+    return existed;
+  }
+}
+
+export function gatewayRegistryFile(): string {
+  return registryFile();
+}

--- a/src/gateway/runtime.ts
+++ b/src/gateway/runtime.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir, getStateDir, readJsonIfExists, writeSecureJson } from "../config/paths.js";
+import { SERVICE_NAME, VERSION } from "../version.js";
+
+export const GATEWAY_ID = "gateway";
+
+export interface GatewayRuntimeState {
+  service: string;
+  version: string;
+  gatewayId: string;
+  pid: number;
+  port: number;
+  adminToken: string;
+  publicUrl: string | null;
+  startedAt: string;
+}
+
+export function gatewayRuntimeFile(): string {
+  return path.join(ensureDir(path.join(getStateDir(), "runtime")), `${GATEWAY_ID}.json`);
+}
+
+export function writeGatewayRuntimeState(state: GatewayRuntimeState): void {
+  writeSecureJson(gatewayRuntimeFile(), state);
+}
+
+export function readGatewayRuntimeState(): GatewayRuntimeState | null {
+  return readJsonIfExists<GatewayRuntimeState>(gatewayRuntimeFile());
+}
+
+export function clearGatewayRuntimeState(): void {
+  try {
+    fs.rmSync(gatewayRuntimeFile(), { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+export interface GatewayHealthPayload {
+  service: string;
+  version: string;
+  gatewayId: string;
+  workspaceId: string | null;
+  status: string;
+}
+
+export async function probeGateway(port: number, timeoutMs = 2000): Promise<GatewayHealthPayload | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const response = await fetch(`http://127.0.0.1:${port}/health`, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!response.ok) return null;
+    const body = (await response.json()) as GatewayHealthPayload;
+    if (body.service !== SERVICE_NAME || body.gatewayId !== GATEWAY_ID || body.version !== VERSION) return null;
+    return body;
+  } catch {
+    return null;
+  }
+}
+
+export async function findLiveGateway(): Promise<GatewayRuntimeState | null> {
+  const runtime = readGatewayRuntimeState();
+  if (!runtime) return null;
+  const health = await probeGateway(runtime.port);
+  return health ? runtime : null;
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1,0 +1,313 @@
+import express, { type Request, type Response, type NextFunction } from "express";
+import type { Server } from "node:http";
+import { randomBytes } from "node:crypto";
+import { Workspace } from "../workspace/manager.js";
+import { WorkspaceRegistry } from "./registry.js";
+import { GATEWAY_ID, clearGatewayRuntimeState, writeGatewayRuntimeState, type GatewayRuntimeState } from "./runtime.js";
+import { AuthStore, authStoreFileFor, migrateLegacyAuthState } from "../auth/store.js";
+import { createOAuthRouter } from "../auth/oauth.js";
+import { bearerAuth } from "../auth/middleware.js";
+import { PairingManager } from "../pairing/manager.js";
+import { createMcpServer } from "../mcp/server.js";
+import { createMcpHttpHandler } from "../mcp/http.js";
+import { CloudflaredQuickTunnel } from "../tunnel/cloudflared.js";
+import { CloudflaredNamedTunnel } from "../tunnel/cloudflared-named.js";
+import type { TunnelProvider } from "../tunnel/provider.js";
+import { namedTunnelBinding, readTunnelState } from "../tunnel/state.js";
+import { Logger, nullLogger } from "../logger/index.js";
+import { DEFAULT_HOST, DEFAULT_PORT } from "../config/paths.js";
+import { SERVICE_NAME, VERSION } from "../version.js";
+
+function tunnelForGateway(logger: Logger): TunnelProvider {
+  const binding = namedTunnelBinding(readTunnelState(GATEWAY_ID));
+  if (binding) {
+    return new CloudflaredNamedTunnel({
+      tunnelName: binding.tunnelName,
+      hostname: binding.hostname,
+      logger,
+    });
+  }
+  return new CloudflaredQuickTunnel(logger);
+}
+
+export interface GatewayOptions {
+  workspaceRoot: string;
+  port?: number;
+  host?: string;
+  logger?: Logger;
+  tunnelProvider?: TunnelProvider;
+  persistRuntime?: boolean;
+  authStoreFile?: string;
+  registryFile?: string;
+  leaseTtlMs?: number;
+  pairingTtlMs?: number;
+  accessTokenTtlMs?: number;
+}
+
+export interface Gateway {
+  registry: WorkspaceRegistry;
+  port: number;
+  host: string;
+  adminToken: string;
+  authStore: AuthStore;
+  pairing: PairingManager;
+  tunnel: TunnelProvider;
+  getPublicBaseUrl(): string | null;
+  localBaseUrl(): string;
+  close(): Promise<void>;
+}
+
+function listen(app: express.Express, host: string, preferredPort: number): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const tryListen = (port: number, allowFallback: boolean): void => {
+      const server = app.listen(port, host);
+      server.once("listening", () => {
+        const address = server.address();
+        const actual = typeof address === "object" && address ? address.port : port;
+        resolve({ server, port: actual });
+      });
+      server.once("error", (error: NodeJS.ErrnoException) => {
+        if (error.code === "EADDRINUSE" && allowFallback) tryListen(0, false);
+        else reject(error);
+      });
+    };
+    tryListen(preferredPort, preferredPort !== 0);
+  });
+}
+
+export async function startGateway(opts: GatewayOptions): Promise<Gateway> {
+  const logger = opts.logger ?? nullLogger;
+  const host = opts.host ?? DEFAULT_HOST;
+  if (host !== "127.0.0.1" && host !== "::1" && host !== "localhost") {
+    throw new Error("The Gateway only binds to loopback addresses. Public exposure goes through the tunnel.");
+  }
+
+  const registry = new WorkspaceRegistry({ file: opts.registryFile, leaseTtlMs: opts.leaseTtlMs });
+  const active = registry.attach(opts.workspaceRoot).workspace;
+  const authStoreFile = opts.authStoreFile ?? authStoreFileFor(GATEWAY_ID);
+  const migration = opts.authStoreFile
+    ? null
+    : migrateLegacyAuthState({ targetFile: authStoreFile, targetWorkspaceId: "*" });
+  if (migration?.migrated) {
+    logger.info(
+      `Migrated ${migration.importedTokens} OAuth token records from ${migration.sourceFiles.length} legacy workspace store(s)`
+    );
+  }
+  const authStore = new AuthStore(GATEWAY_ID, { file: authStoreFile });
+  const pairing = new PairingManager(GATEWAY_ID, { ttlMs: opts.pairingTtlMs });
+  const tunnel = opts.tunnelProvider ?? tunnelForGateway(logger);
+  const adminToken = `c2c_admin_${randomBytes(24).toString("base64url")}`;
+  let publicBaseUrl: string | null = null;
+  let port = 0;
+  const startedAt = new Date().toISOString();
+
+  const app = express();
+  app.set("trust proxy", true);
+  app.disable("x-powered-by");
+  app.use(express.json({ limit: "1mb" }));
+
+  const getBaseUrl = (req: Request): string => {
+    if (publicBaseUrl) return publicBaseUrl;
+    const proto = req.protocol;
+    const hostHeader = req.get("host") ?? `${host}:${port}`;
+    return `${proto}://${hostHeader}`;
+  };
+
+  app.get("/health", (_req, res) => {
+    res.json({
+      service: SERVICE_NAME,
+      version: VERSION,
+      gatewayId: GATEWAY_ID,
+      workspaceId: registry.getActiveId(),
+      status: "ok",
+    });
+  });
+
+  app.use(
+    createOAuthRouter({
+      store: authStore,
+      pairing,
+      workspaceName: () => {
+        try {
+          return registry.active().name;
+        } catch {
+          return "active workspace";
+        }
+      },
+      tokenWorkspaceId: "*",
+      getBaseUrl,
+      logger,
+    })
+  );
+
+  const mcpHandler = createMcpHttpHandler(
+    () => createMcpServer({ workspace: active, resolveWorkspace: (workspaceId) => registry.resolve(workspaceId), logger }),
+    logger
+  );
+  app.all(
+    "/mcp",
+    express.json({ limit: "8mb" }),
+    bearerAuth({ store: authStore, workspaceId: "*", getBaseUrl, logger }),
+    (req: Request, res: Response) => {
+      void mcpHandler(req, res);
+    }
+  );
+
+  const adminGuard = (req: Request, res: Response, next: NextFunction): void => {
+    const remote = req.socket.remoteAddress ?? "";
+    const isLoopback = remote === "127.0.0.1" || remote === "::1" || remote === "::ffff:127.0.0.1";
+    const viaProxy = Boolean(req.headers["cf-connecting-ip"] || req.headers["x-forwarded-for"]);
+    const header = req.headers.authorization ?? "";
+    const token = header.toLowerCase().startsWith("bearer ") ? header.slice(7).trim() : "";
+    if (!isLoopback || viaProxy || token !== adminToken) {
+      res.status(404).end();
+      return;
+    }
+    next();
+  };
+
+  app.post("/admin/attach", adminGuard, (req, res) => {
+    const root = req.body && typeof req.body.workspaceRoot === "string" ? req.body.workspaceRoot : "";
+    if (!root.trim()) {
+      res.status(400).json({ error: "workspace_root_required" });
+      return;
+    }
+    try {
+      const result = registry.attach(root);
+      logger.info(`Attached workspace ${result.workspace.name} (${result.workspace.id})`);
+      res.json({
+        attached: true,
+        created: result.created,
+        workspaceId: result.workspace.id,
+        workspaceName: result.workspace.name,
+        workspaceRoot: result.workspace.root,
+        leaseExpiresAt: result.lease.expiresAt,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(400).json({ error: "invalid_workspace", message });
+    }
+  });
+
+  app.post("/admin/activate", adminGuard, (req, res) => {
+    const id = req.body && typeof req.body.workspaceId === "string" ? req.body.workspaceId : "";
+    try {
+      const workspace = registry.setActive(id);
+      res.json({ active: true, workspaceId: workspace.id, workspaceName: workspace.name });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(404).json({ error: "workspace_not_attached", message });
+    }
+  });
+
+  app.post("/admin/detach", adminGuard, (req, res) => {
+    const id = req.body && typeof req.body.workspaceId === "string" ? req.body.workspaceId : "";
+    res.json({ detached: registry.detach(id), workspaceId: id });
+  });
+
+  app.post("/admin/pairing", adminGuard, (_req, res) => {
+    const session = pairing.create();
+    logger.info("Created Gateway pairing session");
+    res.json({ code: session.code, expiresAt: session.expiresAt });
+  });
+
+  app.get("/admin/info", adminGuard, (_req, res) => {
+    res.json({
+      service: SERVICE_NAME,
+      version: VERSION,
+      gatewayId: GATEWAY_ID,
+      workspaceId: registry.getActiveId(),
+      workspaceName: (() => {
+        try {
+          return registry.active().name;
+        } catch {
+          return null;
+        }
+      })(),
+      workspaces: registry.list(),
+      port,
+      publicUrl: publicBaseUrl,
+      tunnel: tunnel.status(),
+      tokenCount: authStore.tokenCount(),
+      pairingActive: pairing.hasActiveSession(),
+      pid: process.pid,
+      startedAt,
+    });
+  });
+
+  app.post("/admin/tunnel/start", adminGuard, (_req, res) => {
+    tunnel
+      .start(port)
+      .then((url) => {
+        publicBaseUrl = url;
+        persistRuntime();
+        res.json({ url });
+      })
+      .catch((error: Error) => {
+        logger.error(`Gateway tunnel start failed: ${error.message}`);
+        res.status(500).json({ error: "tunnel_failed", message: error.message });
+      });
+  });
+
+  app.post("/admin/tunnel/stop", adminGuard, (_req, res) => {
+    void tunnel.stop().then(() => {
+      publicBaseUrl = null;
+      persistRuntime();
+      res.json({ stopped: true });
+    });
+  });
+
+  app.post("/admin/revoke-all", adminGuard, (_req, res) => {
+    const count = authStore.revokeAll();
+    pairing.invalidateAll();
+    res.json({ revoked: count });
+  });
+
+  let closed = false;
+  const { server, port: actualPort } = await listen(app, host, opts.port ?? DEFAULT_PORT);
+  port = actualPort;
+
+  const persistRuntime = (): void => {
+    if (opts.persistRuntime === false) return;
+    const state: GatewayRuntimeState = {
+      service: SERVICE_NAME,
+      version: VERSION,
+      gatewayId: GATEWAY_ID,
+      pid: process.pid,
+      port,
+      adminToken,
+      publicUrl: publicBaseUrl,
+      startedAt,
+    };
+    writeGatewayRuntimeState(state);
+  };
+  persistRuntime();
+
+  const shutdown = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await tunnel.stop().catch(() => undefined);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (opts.persistRuntime !== false) clearGatewayRuntimeState();
+    logger.info("Gateway stopped");
+  };
+
+  app.post("/admin/shutdown", adminGuard, (_req, res) => {
+    res.json({ shuttingDown: true });
+    setTimeout(() => void shutdown().then(() => process.exit(0)), 100);
+  });
+
+  logger.info(`Gateway listening on ${host}:${port}; active workspace ${active.name} (${active.id})`);
+  return {
+    registry,
+    port,
+    host,
+    adminToken,
+    authStore,
+    pairing,
+    tunnel,
+    getPublicBaseUrl: () => publicBaseUrl,
+    localBaseUrl: () => `http://${host}:${port}`,
+    close: shutdown,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { Workspace, WorkspaceError } from "../workspace/manager.js";
+import { GatewayWorkspaceError } from "../gateway/registry.js";
 import { searchWorkspace } from "../workspace/search.js";
 import { gitDiff, gitInfo, gitStatus, type DiffMode } from "../workspace/git.js";
 import { executionRecordSchema, latestExecutionRecord, readExecutionRecords } from "../execution/records.js";
@@ -36,6 +37,7 @@ function fail(code: string, message: string): ToolResult {
 
 function mapError(error: unknown): ToolResult {
   if (error instanceof WorkspaceError) return fail(error.code, error.message);
+  if (error instanceof GatewayWorkspaceError) return fail(error.code, error.message);
   return fail("INTERNAL_ERROR", error instanceof Error ? error.message : String(error));
 }
 
@@ -178,10 +180,17 @@ const executionOutputOutputSchema = {
 export interface McpContext {
   workspace: Workspace;
   logger: Logger;
+  /** Resolve an opaque workspace id for a multi-workspace Gateway. */
+  resolveWorkspace?: (workspaceId?: string) => Workspace;
 }
 
 export function createMcpServer(ctx: McpContext): McpServer {
-  const { workspace } = ctx;
+  const { workspace: defaultWorkspace } = ctx;
+  const workspaceFor = (workspaceId?: string): Workspace =>
+    ctx.resolveWorkspace ? ctx.resolveWorkspace(workspaceId) : defaultWorkspace;
+  const workspaceIdInput = z.string().min(1).max(128).optional().describe(
+    "Opaque workspace id returned by workspace_info; omit to use the active workspace."
+  );
   const server = new McpServer(
     { name: PRODUCT_NAME, version: VERSION },
     { capabilities: { tools: {} }, instructions: UNTRUSTED_NOTE }
@@ -194,14 +203,15 @@ export function createMcpServer(ctx: McpContext): McpServer {
       description:
         `Get an overview of the connected workspace: identity, project type, languages, ` +
         `frameworks, git state and available scripts. Call this first. ${UNTRUSTED_NOTE}`,
-      inputSchema: {},
+      inputSchema: { workspace_id: workspaceIdInput },
       outputSchema: workspaceInfoOutputSchema,
       annotations: { readOnlyHint: true },
     },
-    async (_args, extra) => {
+    async (args, extra) => {
       const denied = requireScope(extra.authInfo, "workspace.read");
       if (denied) return denied;
       try {
+        const workspace = workspaceFor(args.workspace_id);
         const project = workspace.detectProject();
         const git = gitInfo(workspace.root);
         return okStructured({
@@ -230,6 +240,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `List files and directories under a workspace-relative path. High-noise directories ` +
         `(node_modules, .git, build output) are omitted. Supports pagination. ${UNTRUSTED_NOTE}`,
       inputSchema: {
+        workspace_id: workspaceIdInput,
         path: z.string().default(".").describe("Workspace-relative path, e.g. 'src'"),
         depth: z.number().int().min(1).max(4).default(1).describe("Recursion depth (1-4)"),
         limit: z.number().int().min(1).max(1000).default(200),
@@ -242,6 +253,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "workspace.read");
       if (denied) return denied;
       try {
+        const workspace = workspaceFor(args.workspace_id);
         return okStructured(await workspace.listDirectory(args.path, args));
       } catch (error) {
         return mapError(error);
@@ -258,6 +270,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `400 lines; use start_line/end_line to page through large files. Sensitive files ` +
         `(.env, keys, credentials) are always denied. ${UNTRUSTED_NOTE}`,
       inputSchema: {
+        workspace_id: workspaceIdInput,
         path: z.string().describe("Workspace-relative file path"),
         start_line: z.number().int().min(1).optional().describe("1-based first line to return"),
         end_line: z.number().int().min(1).optional().describe("1-based last line to return"),
@@ -269,6 +282,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "workspace.read");
       if (denied) return denied;
       try {
+        const workspace = workspaceFor(args.workspace_id);
         return okStructured(await workspace.readFile(args.path, { startLine: args.start_line, endLine: args.end_line }));
       } catch (error) {
         return mapError(error);
@@ -284,6 +298,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `Search file contents across the workspace (ripgrep when available). Returns matching ` +
         `lines with file paths and line numbers. ${UNTRUSTED_NOTE}`,
       inputSchema: {
+        workspace_id: workspaceIdInput,
         query: z.string().min(2).describe("Text to search for (literal by default)"),
         path: z.string().optional().describe("Restrict search to this workspace-relative path"),
         glob: z.string().optional().describe("Filename glob filter, e.g. '*.ts'"),
@@ -297,6 +312,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "workspace.search");
       if (denied) return denied;
       try {
+        const workspace = workspaceFor(args.workspace_id);
         return okStructured(await searchWorkspace(workspace, args));
       } catch (error) {
         return mapError(error);
@@ -309,14 +325,15 @@ export function createMcpServer(ctx: McpContext): McpServer {
     {
       title: "Git status",
       description: `Structured git status of the workspace: branch, staged/unstaged/untracked files. ${UNTRUSTED_NOTE}`,
-      inputSchema: {},
+      inputSchema: { workspace_id: workspaceIdInput },
       outputSchema: gitStatusOutputSchema,
       annotations: { readOnlyHint: true },
     },
-    async (_args, extra) => {
+    async (args, extra) => {
       const denied = requireScope(extra.authInfo, "git.read");
       if (denied) return denied;
       try {
+        const workspace = workspaceFor(args.workspace_id);
         return okStructured(gitStatus(workspace.root));
       } catch (error) {
         return mapError(error);
@@ -332,6 +349,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `Git diff with byte-offset pagination. mode: 'unstaged' (default), 'staged', or 'head' ` +
         `(working tree vs HEAD). When hasMore is true, call again with offset=nextOffset. ${UNTRUSTED_NOTE}`,
       inputSchema: {
+        workspace_id: workspaceIdInput,
         mode: z.enum(["unstaged", "staged", "head"]).default("unstaged"),
         path: z.string().optional().describe("Limit the diff to one workspace-relative path"),
         offset: z.number().int().min(0).default(0).describe("Byte offset for pagination"),
@@ -344,6 +362,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
       const denied = requireScope(extra.authInfo, "git.read");
       if (denied) return denied;
       try {
+        const workspace = workspaceFor(args.workspace_id);
         let relPath: string | undefined;
         if (args.path) {
           relPath = workspace.resolve(args.path).rel;
@@ -368,27 +387,32 @@ export function createMcpServer(ctx: McpContext): McpServer {
       description:
         `Summary of the most recent test run reported by the Codex harness. This does NOT run ` +
         `tests; it reads the latest execution record. ${UNTRUSTED_NOTE}`,
-      inputSchema: {},
+      inputSchema: { workspace_id: workspaceIdInput },
       outputSchema: testStatusOutputSchema,
       annotations: { readOnlyHint: true },
     },
-    async (_args, extra) => {
+    async (args, extra) => {
       const denied = requireScope(extra.authInfo, "execution.read");
       if (denied) return denied;
-      const latest = latestExecutionRecord(workspace.id);
-      if (!latest) {
-        return okStructured({ available: false, message: "No execution records yet for this workspace." });
+      try {
+        const workspace = workspaceFor(args.workspace_id);
+        const latest = latestExecutionRecord(workspace.id);
+        if (!latest) {
+          return okStructured({ available: false, message: "No execution records yet for this workspace." });
+        }
+        return okStructured({
+          available: true,
+          taskId: latest.taskId,
+          iteration: latest.iteration,
+          tests: latest.tests,
+          exitStatus: latest.exitStatus,
+          timestamp: latest.timestamp,
+          outputAvailable: Boolean(latest.outputAvailable),
+          outputId: latest.outputId ?? null,
+        });
+      } catch (error) {
+        return mapError(error);
       }
-      return okStructured({
-        available: true,
-        taskId: latest.taskId,
-        iteration: latest.iteration,
-        tests: latest.tests,
-        exitStatus: latest.exitStatus,
-        timestamp: latest.timestamp,
-        outputAvailable: Boolean(latest.outputAvailable),
-        outputId: latest.outputId ?? null,
-      });
     }
   );
 
@@ -400,6 +424,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `Recent Codex execution records for this workspace: task id, iteration, changed files, ` +
         `tests and exit status. Use it after Codex reports EXECUTED. ${UNTRUSTED_NOTE}`,
       inputSchema: {
+        workspace_id: workspaceIdInput,
         limit: z.number().int().min(1).max(50).default(5),
       },
       outputSchema: executionSummaryOutputSchema,
@@ -408,7 +433,12 @@ export function createMcpServer(ctx: McpContext): McpServer {
     async (args, extra) => {
       const denied = requireScope(extra.authInfo, "execution.read");
       if (denied) return denied;
-      return okStructured({ records: readExecutionRecords(workspace.id, args.limit) });
+      try {
+        const workspace = workspaceFor(args.workspace_id);
+        return okStructured({ records: readExecutionRecords(workspace.id, args.limit) });
+      } catch (error) {
+        return mapError(error);
+      }
     }
   );
 
@@ -421,6 +451,7 @@ export function createMcpServer(ctx: McpContext): McpServer {
         `run. Call with action=list first, then action=read and an id. Restricted items have no ` +
         `body. This does not run commands. ${UNTRUSTED_NOTE}`,
       inputSchema: {
+        workspace_id: workspaceIdInput,
         action: z.enum(["list", "read"]).default("list"),
         id: z.number().int().positive().optional(),
         limit: z.number().int().min(1).max(50).default(20),
@@ -431,39 +462,44 @@ export function createMcpServer(ctx: McpContext): McpServer {
     async (args, extra) => {
       const denied = requireScope(extra.authInfo, "execution.read");
       if (denied) return denied;
-      const action = args.action ?? "list";
-      if (action === "list") {
-        const items = listExecutionOutputs(workspace.id, args.limit).map((item) => ({
-          id: item.id,
-          command: item.command,
-          exitCode: item.exitCode,
-          timestamp: item.timestamp,
-          taskId: item.taskId ?? null,
-          iteration: item.iteration ?? null,
-          readable: item.allowed,
-          status: item.allowed ? "readable" : "restricted",
-          truncated: item.truncated,
-          sizeBytes: item.sizeBytes,
-        }));
-        return okStructured({ action: "list", items });
-      }
-      if (args.id === undefined) return fail("INVALID_ARGUMENTS", "read requires id");
-      const result = readExecutionOutput(workspace.id, args.id);
-      if (!result.ok) {
-        if (result.error === "OUTPUT_RESTRICTED") {
-          return fail("OUTPUT_RESTRICTED", "This output was not released for ChatGPT to read.");
+      try {
+        const workspace = workspaceFor(args.workspace_id);
+        const action = args.action ?? "list";
+        if (action === "list") {
+          const items = listExecutionOutputs(workspace.id, args.limit).map((item) => ({
+            id: item.id,
+            command: item.command,
+            exitCode: item.exitCode,
+            timestamp: item.timestamp,
+            taskId: item.taskId ?? null,
+            iteration: item.iteration ?? null,
+            readable: item.allowed,
+            status: item.allowed ? "readable" : "restricted",
+            truncated: item.truncated,
+            sizeBytes: item.sizeBytes,
+          }));
+          return okStructured({ action: "list", items });
         }
-        return fail("NOT_FOUND", `No execution output with id ${args.id}.`);
+        if (args.id === undefined) return fail("INVALID_ARGUMENTS", "read requires id");
+        const result = readExecutionOutput(workspace.id, args.id);
+        if (!result.ok) {
+          if (result.error === "OUTPUT_RESTRICTED") {
+            return fail("OUTPUT_RESTRICTED", "This output was not released for ChatGPT to read.");
+          }
+          return fail("NOT_FOUND", `No execution output with id ${args.id}.`);
+        }
+        return okStructured({
+          action: "read",
+          id: result.meta.id,
+          command: result.meta.command,
+          exitCode: result.meta.exitCode,
+          timestamp: result.meta.timestamp,
+          truncated: result.meta.truncated,
+          text: result.text,
+        });
+      } catch (error) {
+        return mapError(error);
       }
-      return okStructured({
-        action: "read",
-        id: result.meta.id,
-        command: result.meta.command,
-        exitCode: result.meta.exitCode,
-        timestamp: result.meta.timestamp,
-        truncated: result.meta.truncated,
-        text: result.text,
-      });
     }
   );
 

--- a/src/process/daemon.ts
+++ b/src/process/daemon.ts
@@ -4,6 +4,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureDir, getStateDir } from "../config/paths.js";
 import { findBridgeObservation, findLiveBridge, probeBridge, readRuntimeState, type RuntimeState } from "../bridge/runtime.js";
+import {
+  findLiveGateway,
+  probeGateway,
+  readGatewayRuntimeState,
+  type GatewayRuntimeState,
+} from "../gateway/runtime.js";
 import { Workspace } from "../workspace/manager.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -22,6 +28,11 @@ function cliEntry(): { cmd: string; args: string[] } {
 
 export interface EnsureBridgeResult {
   runtime: RuntimeState;
+  spawned: boolean;
+}
+
+export interface EnsureGatewayResult {
+  runtime: GatewayRuntimeState;
   spawned: boolean;
 }
 
@@ -75,18 +86,73 @@ export async function ensureBridge(workspaceRoot: string, opts: { port?: number 
   throw new Error(`Bridge did not become healthy within 20s. See ${logFile}`);
 }
 
+/** Ensure the single multi-workspace Gateway is running and has the workspace attached. */
+export async function ensureGateway(workspaceRoot: string, opts: { port?: number } = {}): Promise<EnsureGatewayResult> {
+  const workspace = new Workspace(workspaceRoot);
+  const existing = await findLiveGateway();
+  if (existing) {
+    await gatewayAdminFetch(existing, "POST", "/admin/attach", { workspaceRoot: workspace.root });
+    return { runtime: existing, spawned: false };
+  }
+  const stale = readGatewayRuntimeState();
+  if (stale) {
+    const health = await probeGateway(stale.port);
+    if (health) throw new Error("Gateway state is uncertain; refusing to start another Gateway.");
+  }
+
+  const logDir = ensureDir(path.join(getStateDir(), "logs"));
+  const logFile = path.join(logDir, "gateway.out.log");
+  const out = fs.openSync(logFile, "a", 0o600);
+  try {
+    fs.chmodSync(logFile, 0o600);
+  } catch {
+    // best effort on Windows / filesystems without chmod semantics
+  }
+  const { cmd, args } = cliEntry();
+  const child = spawn(
+    cmd,
+    [...args, "serve", "--gateway", "--workspace", workspace.root, ...(opts.port ? ["--port", String(opts.port)] : [])],
+    {
+      detached: true,
+      stdio: ["ignore", out, out],
+      env: { ...process.env },
+      windowsHide: true,
+    }
+  );
+  child.unref();
+  fs.closeSync(out);
+
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const runtime = await findLiveGateway();
+    if (runtime) return { runtime, spawned: true };
+    if (child.exitCode !== null && child.exitCode !== 0) {
+      throw new Error(`Gateway process exited with code ${child.exitCode}. See ${logFile}`);
+    }
+  }
+  throw new Error(`Gateway did not become healthy within 20s. See ${logFile}`);
+}
+
 export async function adminFetch<T = unknown>(
   runtime: RuntimeState,
   method: "GET" | "POST",
   route: string,
-  timeoutMs = 60_000
+  timeoutMsOrBody: number | unknown = 60_000,
+  body?: unknown
 ): Promise<T> {
+  const timeoutMs = typeof timeoutMsOrBody === "number" ? timeoutMsOrBody : 60_000;
+  const requestBody = typeof timeoutMsOrBody === "number" ? body : timeoutMsOrBody;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetch(`http://127.0.0.1:${runtime.port}${route}`, {
       method,
-      headers: { Authorization: `Bearer ${runtime.adminToken}` },
+      headers: {
+        Authorization: `Bearer ${runtime.adminToken}`,
+        ...(requestBody === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(requestBody === undefined ? {} : { body: JSON.stringify(requestBody) }),
       signal: controller.signal,
     });
     const body = (await response.json().catch(() => ({}))) as T & { message?: string };
@@ -94,6 +160,36 @@ export async function adminFetch<T = unknown>(
       throw new Error((body as { message?: string }).message ?? `Admin request failed (${response.status})`);
     }
     return body;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Gateway variant of adminFetch. Kept separate in types so bridge callers remain unchanged. */
+export async function gatewayAdminFetch<T = unknown>(
+  runtime: GatewayRuntimeState,
+  method: "GET" | "POST",
+  route: string,
+  body?: unknown,
+  timeoutMs = 60_000
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`http://127.0.0.1:${runtime.port}${route}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${runtime.adminToken}`,
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: controller.signal,
+    });
+    const payload = (await response.json().catch(() => ({}))) as T & { message?: string };
+    if (!response.ok) {
+      throw new Error((payload as { message?: string }).message ?? `Gateway admin request failed (${response.status})`);
+    }
+    return payload;
   } finally {
     clearTimeout(timer);
   }
@@ -107,6 +203,26 @@ export async function stopBridge(workspaceRoot: string): Promise<boolean> {
   if (healthy && healthy.workspaceId === workspace.id) {
     try {
       await adminFetch(runtime, "POST", "/admin/shutdown", 5000);
+      return true;
+    } catch {
+      // fall through to kill
+    }
+  }
+  try {
+    process.kill(runtime.pid, "SIGTERM");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function stopGateway(): Promise<boolean> {
+  const runtime = readGatewayRuntimeState();
+  if (!runtime) return false;
+  const healthy = await probeGateway(runtime.port);
+  if (healthy) {
+    try {
+      await gatewayAdminFetch(runtime, "POST", "/admin/shutdown", undefined, 5000);
       return true;
     } catch {
       // fall through to kill

--- a/tests/auth-migration.test.ts
+++ b/tests/auth-migration.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  AuthStore,
+  migrateLegacyAuthState,
+  type PersistedAuthState,
+} from "../src/auth/store.js";
+import { readJsonIfExists } from "../src/config/paths.js";
+import { isolateStateDir } from "./helpers.js";
+
+describe("legacy OAuth state migration", () => {
+  it("imports matching workspace credentials as global Gateway credentials", () => {
+    const state = isolateStateDir();
+    const authDir = path.join(state, "auth");
+    const endpointDir = path.join(state, "endpoints");
+    fs.mkdirSync(authDir, { recursive: true });
+    fs.mkdirSync(endpointDir, { recursive: true });
+
+    const legacyFile = path.join(authDir, "legacy-workspace.json");
+    const legacy = new AuthStore("legacy-workspace", { file: legacyFile });
+    const client = legacy.registerClient({
+      clientName: "ChatGPT",
+      redirectUris: ["https://chatgpt.com/connector/oauth/test"],
+    });
+    const issued = legacy.issueTokens({
+      clientId: client.clientId,
+      scopes: ["workspace.read", "offline_access"],
+      accessTtlMs: 60_000,
+    });
+    const raw = readJsonIfExists<PersistedAuthState>(legacyFile);
+    if (!raw) throw new Error("legacy auth state was not written");
+    raw.tokens.push({
+      hash: "expired-hash",
+      kind: "access",
+      clientId: client.clientId,
+      workspaceId: "legacy-workspace",
+      scopes: ["workspace.read"],
+      issuedAt: Date.now() - 120_000,
+      expiresAt: Date.now() - 60_000,
+      revoked: false,
+    });
+    fs.writeFileSync(legacyFile, JSON.stringify(raw));
+
+    fs.writeFileSync(
+      path.join(endpointDir, "gateway.json"),
+      JSON.stringify({ workspaceId: "gateway", mcpUrl: "https://example.test/mcp" })
+    );
+    fs.writeFileSync(
+      path.join(endpointDir, "legacy-workspace.json"),
+      JSON.stringify({ workspaceId: "legacy-workspace", mcpUrl: "https://example.test/mcp" })
+    );
+    fs.writeFileSync(
+      path.join(endpointDir, "unrelated.json"),
+      JSON.stringify({ workspaceId: "unrelated", mcpUrl: "https://other.test/mcp" })
+    );
+    fs.writeFileSync(
+      path.join(authDir, "unrelated.json"),
+      JSON.stringify({ clients: [], tokens: [{ ...raw.tokens[0], hash: "unrelated-hash" }] })
+    );
+
+    const targetFile = path.join(authDir, "gateway.json");
+    const result = migrateLegacyAuthState({ targetFile });
+    expect(result.migrated).toBe(true);
+    expect(result.importedTokens).toBe(2);
+    expect(result.importedClients).toBe(1);
+
+    const gateway = new AuthStore("gateway", { file: targetFile });
+    expect(gateway.tokenCount()).toBe(2);
+    expect(gateway.verifyAccessToken(issued.accessToken)).toMatchObject({
+      ok: true,
+      record: { workspaceId: "*" },
+    });
+
+    const repeated = migrateLegacyAuthState({ targetFile });
+    expect(repeated.migrated).toBe(false);
+    expect(gateway.tokenCount()).toBe(2);
+  });
+});

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { startGateway, type Gateway } from "../src/gateway/server.js";
+import type { TunnelProvider } from "../src/tunnel/provider.js";
+import { cleanup, isolateStateDir, makeTmpDir, write } from "./helpers.js";
+
+class NoopTunnel implements TunnelProvider {
+  readonly name = "test";
+  private url: string | null = null;
+  async start(): Promise<string> {
+    this.url = "https://gateway.test.example";
+    return this.url;
+  }
+  async stop(): Promise<void> {
+    this.url = null;
+  }
+  async restart(): Promise<string> {
+    return this.start();
+  }
+  status() {
+    return { running: this.url !== null, url: this.url, provider: this.name };
+  }
+  getPublicUrl(): string | null {
+    return this.url;
+  }
+  async doctor() {
+    return { provider: this.name, binaryFound: true, binaryPath: null, running: this.url !== null, url: this.url, problems: [] };
+  }
+}
+
+describe("multi-workspace Gateway", () => {
+  let gateway: Gateway;
+  let rootA: string;
+  let rootB: string;
+  let client: Client;
+
+  beforeAll(async () => {
+    isolateStateDir();
+    rootA = makeTmpDir("gateway-a");
+    rootB = makeTmpDir("gateway-b");
+    write(rootA, "a.txt", "workspace A\n");
+    write(rootB, "b.txt", "workspace B\n");
+    gateway = await startGateway({
+      workspaceRoot: rootA,
+      port: 0,
+      persistRuntime: false,
+      authStoreFile: `${makeTmpDir("gateway-auth")}/store.json`,
+      registryFile: `${makeTmpDir("gateway-registry")}/workspaces.json`,
+      tunnelProvider: new NoopTunnel(),
+    });
+
+    const attach = await fetch(`${gateway.localBaseUrl()}/admin/attach`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${gateway.adminToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ workspaceRoot: rootB }),
+    });
+    expect(attach.status).toBe(200);
+
+    const token = gateway.authStore.issueTokens({
+      clientId: "gateway-test",
+      scopes: ["workspace.read", "workspace.search", "git.read", "execution.read"],
+      workspaceId: "*",
+    });
+    client = new Client({ name: "gateway-test-client", version: "1.0.0" });
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(`${gateway.localBaseUrl()}/mcp`), {
+        requestInit: { headers: { authorization: `Bearer ${token.accessToken}` } },
+      })
+    );
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await gateway.close();
+    cleanup(rootA);
+    cleanup(rootB);
+  });
+
+  it("attaches new workspaces without a static directory registration", async () => {
+    expect(gateway.registry.list().map((entry) => entry.workspaceId)).toEqual(
+      expect.arrayContaining([gateway.registry.active().id])
+    );
+    expect(gateway.registry.list()).toHaveLength(2);
+  });
+
+  it("routes the active and explicitly selected opaque workspace", async () => {
+    const active = await client.callTool({ name: "workspace_info", arguments: {} });
+    const activeInfo = JSON.parse((active.content as { text: string }[])[0].text) as { workspaceId: string; workspaceName: string };
+    expect(activeInfo.workspaceId).toBe(gateway.registry.active().id);
+    expect(activeInfo.workspaceName).toContain("gateway-b");
+
+    const workspaceA = gateway.registry.list().find((entry) => entry.workspaceRoot === rootA)?.workspaceId;
+    const activate = await fetch(`${gateway.localBaseUrl()}/admin/activate`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${gateway.adminToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ workspaceId: workspaceA }),
+    });
+    expect(activate.status).toBe(200);
+    const other = await client.callTool({
+      name: "workspace_info",
+      arguments: { workspace_id: workspaceA },
+    });
+    const otherInfo = JSON.parse((other.content as { text: string }[])[0].text) as { workspaceId: string; workspaceName: string };
+    expect(otherInfo.workspaceName).toContain("gateway-a");
+  });
+
+  it("never accepts a raw filesystem path as workspace context", async () => {
+    const result = await client.callTool({ name: "workspace_info", arguments: { workspace_id: rootA } });
+    expect(result.isError).toBe(true);
+    expect((result.content as { text: string }[])[0].text).toMatch(/WORKSPACE_NOT_(ATTACHED|ACTIVE)/);
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared loopback Gateway with short-lived automatic workspace leases
- reuse one global OAuth/MCP connector across Codex workspaces
- add Gateway CLI commands and update the Skill/docs to attach the current workspace automatically
- migrate legacy per-workspace OAuth hashes once into the Gateway with wildcard workspace binding
- keep active-workspace isolation and reject raw filesystem paths from MCP selectors

## Verification

- pnpm typecheck
- pnpm build
- pnpm test
- Windows-native typecheck/build
- verified the existing fixed endpoint https://example.liutingqiu.xyz/mcp after migration

The current workspace no longer requires a manually maintained directory registry; each new Codex task refreshes its local lease through c2c gateway attach.