### PR TITLE
fix(windows): hide background subprocess consoles

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -814,6 +814,7 @@ function runGit(args: string[]): { ok: boolean; stdout: string } {
     encoding: "utf8",
     timeout: 8000,
     env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    windowsHide: true,
   });
   return { ok: result.status === 0, stdout: (result.stdout ?? "").trim() };
 }

--- a/src/tunnel/detect.ts
+++ b/src/tunnel/detect.ts
@@ -30,7 +30,11 @@ export function findBinary(name: string): string | null {
     if (configured) return configured;
   }
   try {
-    const probe = spawnSync(exe, ["--version"], { stdio: "ignore", timeout: 5000 });
+    const probe = spawnSync(exe, ["--version"], {
+      stdio: "ignore",
+      timeout: 5000,
+      windowsHide: true,
+    });
     if (probe.status === 0 || probe.status === 1) return exe; // on PATH
   } catch {
     // not on PATH

--- a/src/tunnel/named-provision.ts
+++ b/src/tunnel/named-provision.ts
@@ -166,6 +166,7 @@ export class ProcessCloudflaredAccount implements CloudflaredAccount {
     const result = spawnSync(this.binary(), args, {
       encoding: "utf8",
       timeout: COMMAND_TIMEOUT_MS,
+      windowsHide: true,
     });
     return {
       ok: result.status === 0,

--- a/src/workspace/git.ts
+++ b/src/workspace/git.ts
@@ -14,6 +14,7 @@ export function runGit(root: string, args: string[]): GitCommandResult {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
     timeout: 30_000,
+    windowsHide: true,
   });
   return {
     ok: result.status === 0,

--- a/src/workspace/search.ts
+++ b/src/workspace/search.ts
@@ -45,7 +45,11 @@ export function findRipgrep(): string | null {
   }
   for (const candidate of RG_CANDIDATES) {
     try {
-      const result = spawnSync(candidate, ["--version"], { stdio: "ignore", timeout: 3000 });
+      const result = spawnSync(candidate, ["--version"], {
+        stdio: "ignore",
+        timeout: 3000,
+        windowsHide: true,
+      });
       if (result.status === 0) {
         cachedRg = candidate;
         return candidate;
@@ -77,7 +81,7 @@ async function searchWithRipgrep(
   args.push("--", opts.query, searchAbs);
 
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(rgBin, args, { cwd: ws.root });
+    const child = spawn(rgBin, args, { cwd: ws.root, windowsHide: true });
     const matches: SearchMatch[] = [];
     let truncated = false;
     const rl = readline.createInterface({ input: child.stdout });

--- a/tests/windows-process.test.ts
+++ b/tests/windows-process.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import { makeTmpDir, cleanup, makeGitRepo, write } from "./helpers.js";
+
+const spawnSyncCalls: { file: string; args: any[]; options: any }[] = [];
+const spawnCalls: { file: string; args: any[]; options: any }[] = [];
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawnSync: (file: string, args: any, options: any) => {
+      spawnSyncCalls.push({ file, args, options });
+      return actual.spawnSync(file, args, options);
+    },
+    spawn: (file: string, args: any, options: any) => {
+      spawnCalls.push({ file, args, options });
+      return actual.spawn(file, args, options);
+    },
+  };
+});
+
+// Import modules under test after mock is established
+import { runGit } from "../src/workspace/git.js";
+import { findRipgrep, resetRipgrepCache, searchWorkspace } from "../src/workspace/search.js";
+import { Workspace } from "../src/workspace/manager.js";
+import { findBinary } from "../src/tunnel/detect.js";
+import { ProcessCloudflaredAccount } from "../src/tunnel/named-provision.js";
+
+describe("Windows background subprocess windowsHide: true (RED verification)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    spawnSyncCalls.length = 0;
+    spawnCalls.length = 0;
+    tmpDir = makeTmpDir("win-process-test");
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it("1. runGit in src/workspace/git.ts passes windowsHide: true", () => {
+    makeGitRepo(tmpDir);
+    spawnSyncCalls.length = 0;
+    runGit(tmpDir, ["status", "--porcelain"]);
+    const gitCall = spawnSyncCalls.find((c) => c.file === "git");
+    expect(gitCall).toBeDefined();
+    expect(gitCall?.options).toHaveProperty("windowsHide", true);
+  });
+
+  it("2. findRipgrep in src/workspace/search.ts passes windowsHide: true for candidate probe", () => {
+    resetRipgrepCache();
+    findRipgrep();
+    const probeCall = spawnSyncCalls.find((c) => Array.isArray(c.args) && c.args[0] === "--version");
+    expect(probeCall).toBeDefined();
+    expect(probeCall?.options).toHaveProperty("windowsHide", true);
+  });
+
+  it("3. searchWithRipgrep in src/workspace/search.ts passes windowsHide: true for search process", async () => {
+    process.env.C2C_RG_PATH = "fake-rg";
+    resetRipgrepCache();
+    write(tmpDir, "sample.txt", "hello windowsHide\n");
+    const ws = new Workspace(tmpDir);
+    spawnCalls.length = 0;
+    try {
+      await searchWorkspace(ws, { query: "hello" });
+    } catch {
+      // rg execution may fail with fake binary, but spawn was called
+    } finally {
+      delete process.env.C2C_RG_PATH;
+      resetRipgrepCache();
+    }
+    const searchCall = spawnCalls.find((c) => c.file === "fake-rg");
+    expect(searchCall).toBeDefined();
+    expect(searchCall?.options).toHaveProperty("windowsHide", true);
+  });
+
+  it("4. findBinary in src/tunnel/detect.ts passes windowsHide: true for binary probe", () => {
+    findBinary("cloudflared");
+    const probeCall = spawnSyncCalls.find((c) => Array.isArray(c.args) && c.args[0] === "--version");
+    expect(probeCall).toBeDefined();
+    expect(probeCall?.options).toHaveProperty("windowsHide", true);
+  });
+
+  it("5. ProcessCloudflaredAccount.run in src/tunnel/named-provision.ts passes windowsHide: true", async () => {
+    const account = new ProcessCloudflaredAccount("fake-cloudflared");
+    try {
+      await account.listTunnels();
+    } catch {
+      // Expected to fail execution, but spawnSync should record call
+    }
+    const provisionCall = spawnSyncCalls.find((c) => c.file === "fake-cloudflared");
+    expect(provisionCall).toBeDefined();
+    expect(provisionCall?.options).toHaveProperty("windowsHide", true);
+  });
+
+  it("6. src/cli/index.ts update-check runGit passes windowsHide: true", () => {
+    const cliSource = fs.readFileSync(path.resolve("src/cli/index.ts"), "utf8");
+    // Verify runGit under update-check in cli/index.ts includes windowsHide: true
+    const updateCheckSection = cliSource.slice(cliSource.indexOf("// ---------------------------------------------------------------- update-check"));
+    const runGitSnippet = updateCheckSection.slice(0, updateCheckSection.indexOf("program"));
+    expect(runGitSnippet).toContain("windowsHide: true");
+  });
+});


### PR DESCRIPTION
## Summary

Fix transient console-window flashes on Windows caused by short-lived background subprocesses spawned by C2C.

Background `git`, `rg`, and non-interactive `cloudflared` calls did not set Node.js `windowsHide`, whose default is `false` on Windows.

This PR adds `windowsHide: true` only to non-interactive background subprocess calls.

Interactive flows such as `cloudflared tunnel login` and the foreground CLI fallback remain unchanged.

## Root cause

C2C already hid its long-running bridge and tunnel processes, but several short-lived subprocess calls still used the default Windows console behavior.

When C2C runs under GUI-hosted environments, those short-lived console processes can briefly create visible `conhost.exe` windows.

## Changes

Adds `windowsHide: true` to background subprocess calls in:

- `src/workspace/git.ts`
- `src/workspace/search.ts`
- `src/tunnel/detect.ts`
- `src/tunnel/named-provision.ts`
- `src/cli/index.ts`

Adds regression coverage in:

- `tests/windows-process.test.ts`

## Intentionally unchanged

The following interactive/foreground flows were intentionally left unchanged:

- `bin/c2c.js`
- `ProcessCloudflaredAccount.login()`
- long-running bridge/tunnel processes that already use `windowsHide: true`

## Verification

Verified with:

- regression tests for all 6 affected call sites
- relevant git/search/tunnel test suites
- `pnpm typecheck`
- full `pnpm test`
- `pnpm build`
- Windows process-level validation under repeated `git` / `rg` / `cloudflared` activity

Full suite result:

`16 test files, 164 tests passed`

Windows validation observed:

`0 conhost.exe processes spawned by C2C-owned git/rg/cloudflared background subprocesses`

## Scope

This PR only addresses console flashing caused by subprocesses owned by `codex-with-chatgpt`.

It does not attempt to address unrelated console-window behavior from Codex Desktop, ChatGPT Desktop, PowerShell, or other external processes.
