### PR TITLE
feat(tunnel): allow choosing the cloudflared transport via C2C_TUNNEL_PROTOCOL

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,6 +71,22 @@ The Skill installs this automatically during setup.
 If cloudflared is installed in a custom location that is not on `PATH`, set
 `C2C_CLOUDFLARED_PATH` to the executable's absolute path before running `c2c`.
 
+### The public connection keeps dropping (`Connection terminated`, `no recent network activity`)
+`c2c status` shows the tunnel running but its `detail` line repeats
+`ERR Connection terminated ... control stream error` or
+`failed to accept QUIC stream: timeout: no recent network activity`, and ChatGPT
+intermittently reports the connector as unavailable. cloudflared defaults to
+QUIC (UDP); corporate firewalls and some NATs silently drop idle UDP flows, so
+the tunnel reconnects every few minutes and tool calls that land in the gap fail.
+
+Run the tunnel over TCP instead by setting `C2C_TUNNEL_PROTOCOL=http2` in the
+environment that starts the bridge (`auto` and `quic` are also accepted; an
+unknown value refuses to start rather than silently falling back). The setting
+applies to both temporary and named tunnels and takes effect on the next bridge
+start — a temporary address changes when the bridge restarts, so reconnect the
+ChatGPT connector afterwards as usual. `c2c logs` then shows
+`cloudflared transport protocol: http2`.
+
 ### Every new Codex chat “repairs” the connection / cannot write logs
 The C2C state directory lives outside the project (macOS:
 `~/Library/Application Support/codex-with-chatgpt`; Windows:

--- a/src/bridge/server.ts
+++ b/src/bridge/server.ts
@@ -10,6 +10,7 @@ import { createMcpServer } from "../mcp/server.js";
 import { createMcpHttpHandler } from "../mcp/http.js";
 import { CloudflaredQuickTunnel } from "../tunnel/cloudflared.js";
 import { CloudflaredNamedTunnel } from "../tunnel/cloudflared-named.js";
+import { resolveTunnelProtocol } from "../tunnel/protocol.js";
 import type { TunnelProvider } from "../tunnel/provider.js";
 import { namedTunnelBinding, readTunnelState } from "../tunnel/state.js";
 import { Logger, nullLogger } from "../logger/index.js";
@@ -18,15 +19,17 @@ import { SERVICE_NAME, VERSION } from "../version.js";
 import { writeRuntimeState, clearRuntimeState, type RuntimeState } from "./runtime.js";
 
 function tunnelForWorkspace(workspaceId: string, logger: Logger): TunnelProvider {
+  const protocol = resolveTunnelProtocol();
   const binding = namedTunnelBinding(readTunnelState(workspaceId));
   if (binding) {
     return new CloudflaredNamedTunnel({
       tunnelName: binding.tunnelName,
       hostname: binding.hostname,
       logger,
+      protocol,
     });
   }
-  return new CloudflaredQuickTunnel(logger);
+  return new CloudflaredQuickTunnel(logger, undefined, { protocol });
 }
 
 export interface BridgeOptions {

--- a/src/tunnel/cloudflared-named.ts
+++ b/src/tunnel/cloudflared-named.ts
@@ -3,6 +3,7 @@ import readline from "node:readline";
 import type { Logger } from "../logger/index.js";
 import { nullLogger } from "../logger/index.js";
 import { findBinary } from "./detect.js";
+import { tunnelProtocolArgs, type TunnelProtocol } from "./protocol.js";
 import type { TunnelDoctorReport, TunnelProvider, TunnelStatus } from "./provider.js";
 
 const CONNECTED_RE = /registered tunnel connection/i;
@@ -14,6 +15,25 @@ export interface CloudflaredNamedTunnelOptions {
   logger?: Logger;
   binaryOverride?: string;
   startTimeoutMs?: number;
+  /** cloudflared transport (`--protocol`); omitted keeps cloudflared's default. */
+  protocol?: TunnelProtocol | null;
+}
+
+/** Arguments for `cloudflared tunnel run <name>` against a local bridge port. */
+export function namedTunnelArgs(
+  tunnelName: string,
+  localPort: number,
+  protocol: TunnelProtocol | null | undefined
+): string[] {
+  return [
+    "tunnel",
+    "--no-autoupdate",
+    "--url",
+    `http://127.0.0.1:${localPort}`,
+    ...tunnelProtocolArgs(protocol),
+    "run",
+    tunnelName,
+  ];
 }
 
 export function normalizeNamedTunnelHostname(hostname: string): string {
@@ -38,6 +58,7 @@ export class CloudflaredNamedTunnel implements TunnelProvider {
   private readonly logger: Logger;
   private readonly binaryOverride?: string;
   private readonly startTimeoutMs: number;
+  private readonly protocol: TunnelProtocol | null;
   private child: ChildProcess | null = null;
   private connected = false;
   private lastError: string | null = null;
@@ -52,6 +73,7 @@ export class CloudflaredNamedTunnel implements TunnelProvider {
     this.logger = opts.logger ?? nullLogger;
     this.binaryOverride = opts.binaryOverride;
     this.startTimeoutMs = opts.startTimeoutMs ?? 45_000;
+    this.protocol = opts.protocol ?? null;
   }
 
   private binary(): string | null {
@@ -72,21 +94,14 @@ export class CloudflaredNamedTunnel implements TunnelProvider {
     }
 
     return new Promise<string>((resolve, reject) => {
-      const child = spawn(
-        bin,
-        [
-          "tunnel",
-          "--no-autoupdate",
-          "--url",
-          `http://127.0.0.1:${localPort}`,
-          "run",
-          this.tunnelName,
-        ],
-        { stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
-      );
+      const child = spawn(bin, namedTunnelArgs(this.tunnelName, localPort, this.protocol), {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
       this.child = child;
       this.connected = false;
       this.lastError = null;
+      if (this.protocol) this.logger.info(`cloudflared transport protocol: ${this.protocol}`);
       let settled = false;
 
       const finish = (fn: () => void): void => {

--- a/src/tunnel/cloudflared.ts
+++ b/src/tunnel/cloudflared.ts
@@ -4,6 +4,7 @@ import type { Logger } from "../logger/index.js";
 import { nullLogger } from "../logger/index.js";
 import { SERVICE_NAME } from "../version.js";
 import { findBinary } from "./detect.js";
+import { tunnelProtocolArgs, type TunnelProtocol } from "./protocol.js";
 import type { TunnelDoctorReport, TunnelProvider, TunnelStatus } from "./provider.js";
 
 const QUICK_TUNNEL_URL_RE = /https:\/\/[^\s|]+/gi;
@@ -53,6 +54,8 @@ export function parseQuickTunnelUrl(line: string): string | null {
 
 export interface CloudflaredQuickTunnelOptions {
   startTimeoutMs?: number;
+  /** cloudflared transport (`--protocol`); omitted keeps cloudflared's default. */
+  protocol?: TunnelProtocol | null;
   spawnImpl?: (
     command: string,
     args: string[],
@@ -72,6 +75,7 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
   private url: string | null = null;
   private lastError: string | null = null;
   private readonly startTimeoutMs: number;
+  private readonly protocol: TunnelProtocol | null;
   private readonly spawnImpl: NonNullable<CloudflaredQuickTunnelOptions["spawnImpl"]>;
   private readonly fetchImpl: NonNullable<CloudflaredQuickTunnelOptions["fetchImpl"]>;
   private starting: Promise<string> | null = null;
@@ -83,6 +87,7 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
     options: CloudflaredQuickTunnelOptions = {}
   ) {
     this.startTimeoutMs = options.startTimeoutMs ?? 45_000;
+    this.protocol = options.protocol ?? null;
     this.spawnImpl = options.spawnImpl ?? ((command, args, spawnOptions) => spawn(command, args, spawnOptions));
     this.fetchImpl = options.fetchImpl ?? ((input, init) => fetch(input, init));
   }
@@ -118,7 +123,13 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
       try {
         child = this.spawnImpl(
           bin,
-          ["tunnel", "--url", `http://127.0.0.1:${localPort}`, "--no-autoupdate"],
+          [
+            "tunnel",
+            "--url",
+            `http://127.0.0.1:${localPort}`,
+            "--no-autoupdate",
+            ...tunnelProtocolArgs(this.protocol),
+          ],
           { stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
         );
       } catch (error) {
@@ -128,6 +139,7 @@ export class CloudflaredQuickTunnel implements TunnelProvider {
       this.child = child;
       this.url = null;
       this.lastError = null;
+      if (this.protocol) this.logger.info(`cloudflared transport protocol: ${this.protocol}`);
       let settled = false;
       let candidateUrl: string | null = null;
       let cancel: (() => void) | null = null;

--- a/src/tunnel/protocol.ts
+++ b/src/tunnel/protocol.ts
@@ -1,0 +1,27 @@
+/** Transport protocols accepted by cloudflared's `--protocol` flag. */
+export const TUNNEL_PROTOCOLS = ["auto", "quic", "http2"] as const;
+export type TunnelProtocol = (typeof TUNNEL_PROTOCOLS)[number];
+
+/**
+ * Read the transport protocol override from `C2C_TUNNEL_PROTOCOL`.
+ *
+ * Unset or empty keeps cloudflared's own default (QUIC). Networks that drop
+ * idle UDP flows (corporate firewalls, some NATs) keep terminating QUIC
+ * connections with "no recent network activity"; `http2` runs the tunnel over
+ * TCP instead. An unknown value fails loudly rather than silently falling back.
+ */
+export function resolveTunnelProtocol(env: NodeJS.ProcessEnv = process.env): TunnelProtocol | null {
+  const raw = env.C2C_TUNNEL_PROTOCOL?.trim().toLowerCase();
+  if (!raw) return null;
+  if (!TUNNEL_PROTOCOLS.includes(raw as TunnelProtocol)) {
+    throw new Error(
+      `C2C_TUNNEL_PROTOCOL must be one of ${TUNNEL_PROTOCOLS.join(", ")} (got "${raw}")`
+    );
+  }
+  return raw as TunnelProtocol;
+}
+
+/** Extra cloudflared arguments for the chosen protocol; empty keeps cloudflared's default. */
+export function tunnelProtocolArgs(protocol: TunnelProtocol | null | undefined): string[] {
+  return protocol ? ["--protocol", protocol] : [];
+}

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -9,7 +9,8 @@ import {
   parseQuickTunnelUrl,
   type CloudflaredQuickTunnelOptions,
 } from "../src/tunnel/cloudflared.js";
-import { normalizeNamedTunnelHostname } from "../src/tunnel/cloudflared-named.js";
+import { namedTunnelArgs, normalizeNamedTunnelHostname } from "../src/tunnel/cloudflared-named.js";
+import { resolveTunnelProtocol, tunnelProtocolArgs } from "../src/tunnel/protocol.js";
 import { hostnameSlug, parseZoneInput, suggestedNamedHostname } from "../src/tunnel/hostname.js";
 import {
   chooseQuickTunnel,
@@ -40,13 +41,18 @@ class FakeCloudflaredProcess extends EventEmitter {
   });
 }
 
-function setupTunnel(fetchImpl: FetchImpl, startTimeoutMs = 1_000) {
+function setupTunnel(
+  fetchImpl: FetchImpl,
+  startTimeoutMs = 1_000,
+  extra: Pick<CloudflaredQuickTunnelOptions, "protocol"> = {}
+) {
   const child = new FakeCloudflaredProcess();
   const spawnImpl = vi.fn(() => child as unknown as ChildProcess);
   const tunnel = new CloudflaredQuickTunnel(undefined, "cloudflared", {
     spawnImpl,
     fetchImpl,
     startTimeoutMs,
+    ...extra,
   });
   return { child, spawnImpl, tunnel };
 }
@@ -115,6 +121,21 @@ describe("CloudflaredQuickTunnel", () => {
       signal: expect.any(AbortSignal),
     });
     expect(tunnel.status()).toMatchObject({ running: true, url: QUICK_URL });
+    await tunnel.stop();
+  });
+
+  it("passes the configured transport protocol to cloudflared", async () => {
+    const fetchImpl = vi.fn(async () => healthResponse());
+    const { child, spawnImpl, tunnel } = setupTunnel(fetchImpl, 1_000, { protocol: "http2" });
+    const starting = tunnel.start(3333);
+    announceUrl(child);
+
+    await expect(starting).resolves.toBe(QUICK_URL);
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "cloudflared",
+      ["tunnel", "--url", "http://127.0.0.1:3333", "--no-autoupdate", "--protocol", "http2"],
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
+    );
     await tunnel.stop();
   });
 
@@ -200,6 +221,48 @@ describe("CloudflaredQuickTunnel", () => {
     expect(calls).toBe(2);
     expect(cancelBody).toHaveBeenCalledTimes(1);
     await tunnel.stop();
+  });
+});
+
+describe("tunnel transport protocol", () => {
+  it("keeps cloudflared's default when C2C_TUNNEL_PROTOCOL is unset or empty", () => {
+    expect(resolveTunnelProtocol({})).toBeNull();
+    expect(resolveTunnelProtocol({ C2C_TUNNEL_PROTOCOL: "  " })).toBeNull();
+    expect(tunnelProtocolArgs(null)).toEqual([]);
+  });
+
+  it("accepts the cloudflared protocol names case-insensitively", () => {
+    expect(resolveTunnelProtocol({ C2C_TUNNEL_PROTOCOL: "HTTP2" })).toBe("http2");
+    expect(resolveTunnelProtocol({ C2C_TUNNEL_PROTOCOL: " quic " })).toBe("quic");
+    expect(resolveTunnelProtocol({ C2C_TUNNEL_PROTOCOL: "auto" })).toBe("auto");
+    expect(tunnelProtocolArgs("http2")).toEqual(["--protocol", "http2"]);
+  });
+
+  it("rejects unknown protocols instead of silently falling back", () => {
+    expect(() => resolveTunnelProtocol({ C2C_TUNNEL_PROTOCOL: "tcp" })).toThrow(
+      /C2C_TUNNEL_PROTOCOL must be one of auto, quic, http2/
+    );
+  });
+
+  it("places --protocol before the named tunnel run subcommand", () => {
+    expect(namedTunnelArgs("c2c-demo", 4242, "http2")).toEqual([
+      "tunnel",
+      "--no-autoupdate",
+      "--url",
+      "http://127.0.0.1:4242",
+      "--protocol",
+      "http2",
+      "run",
+      "c2c-demo",
+    ]);
+    expect(namedTunnelArgs("c2c-demo", 4242, null)).toEqual([
+      "tunnel",
+      "--no-autoupdate",
+      "--url",
+      "http://127.0.0.1:4242",
+      "run",
+      "c2c-demo",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Problem

cloudflared defaults to QUIC (UDP). On networks that drop idle UDP flows — corporate firewalls, some NATs — the quick tunnel keeps dying and reconnecting:

```
ERR Connection terminated error="control stream error: context deadline exceeded"
ERR Connection terminated error="accept stream listener error: failed to accept QUIC stream: timeout: no recent network activity"
```

cloudflared recovers on its own, but every MCP call that lands in the gap fails. From ChatGPT's side the connector intermittently returns "Resource not found" / `workspace_info` fails, and the Skill's doctor gate (correctly) refuses to send `INIT` while the tunnel is mid-reconnect. On the affected machine this happened twice within 20 minutes, which is enough to break most C2C loops.

## Change

Read `C2C_TUNNEL_PROTOCOL` (`auto` | `quic` | `http2`) when the bridge builds its tunnel provider and pass it to cloudflared as `--protocol`, for both quick and named tunnels.

- Unset / empty → no flag is added; behaviour is byte-for-byte what it is today.
- Unknown value → the bridge refuses to start and lists the accepted values, instead of silently using QUIC.
- The chosen protocol is logged (`cloudflared transport protocol: http2`) so `c2c logs` can confirm it.
- Follows the existing `C2C_CLOUDFLARED_PATH` / `C2C_STATE_DIR` env-var convention; the named-tunnel argument list is now a small exported pure function so it can be unit-tested.

A per-project `.c2c.json` field was considered and rejected: the transport is a property of the machine's network, not of the workspace, and one setting should cover every workspace on that machine.

## Verification

- `pnpm test`: 16/16 files pass (5 new tests in `tests/tunnel.test.ts` cover env parsing, case-insensitivity, the rejection path, and the exact spawn arguments for both providers).
- Against real cloudflared 2026.9.0 on Windows: the quick-tunnel form logs `Initial protocol http2` and registers with `protocol=http2`; `cloudflared tunnel --no-autoupdate --url ... --protocol http2 run --help` accepts the flag at that position.

## Docs

New troubleshooting entry describing the symptom and the setting. It also notes that a temporary address changes on the restart needed to apply it, so the connector has to be reconnected once — same as any other bridge restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
