### PR TITLE
fix(tunnel): replace stale named DNS routes

### DIFF
--- a/src/tunnel/cloudflared-named.ts
+++ b/src/tunnel/cloudflared-named.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import readline from "node:readline";
+import { devNull } from "node:os";
 import type { Logger } from "../logger/index.js";
 import { nullLogger } from "../logger/index.js";
 import { findBinary } from "./detect.js";
@@ -77,6 +78,11 @@ export class CloudflaredNamedTunnel implements TunnelProvider {
         bin,
         [
           "tunnel",
+          // Ignore unrelated user ingress rules and tunnel IDs from the
+          // default cloudflared config. This named tunnel supplies its own
+          // target and local service explicitly.
+          "--config",
+          devNull,
           "--no-autoupdate",
           "--url",
           `http://127.0.0.1:${localPort}`,

--- a/src/tunnel/named-provision.ts
+++ b/src/tunnel/named-provision.ts
@@ -157,7 +157,11 @@ export class ProcessCloudflaredAccount implements CloudflaredAccount {
   }
 
   async routeDns(tunnelName: string, hostname: string): Promise<void> {
-    const result = this.run(["tunnel", "route", "dns", tunnelName, hostname]);
+    // A previous failed or replaced C2C tunnel may leave the hostname routed to
+    // an obsolete tunnel. Reusing that record produces Cloudflare 530 even
+    // while the new tunnel itself is connected, so route the exact requested
+    // hostname to the exact workspace tunnel idempotently.
+    const result = this.run(["tunnel", "route", "dns", "--overwrite-dns", tunnelName, hostname]);
     if (result.ok || isBenignRouteError(`${result.stdout}\n${result.stderr}`)) return;
     throw new Error(result.stderr || result.stdout || `Unable to route ${hostname}`);
   }

--- a/tests/tunnel.test.ts
+++ b/tests/tunnel.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import path from "node:path";
 import type { ChildProcess } from "node:child_process";
 import { PassThrough } from "node:stream";
 import { findBinary } from "../src/tunnel/detect.js";
@@ -16,6 +17,7 @@ import {
   isBenignRouteError,
   parseCreatedTunnel,
   parseTunnelList,
+  ProcessCloudflaredAccount,
   provisionNamedTunnel,
   type CloudflaredAccount,
 } from "../src/tunnel/named-provision.js";
@@ -288,6 +290,25 @@ ID                                   NAME          CREATED
 
   it("treats an existing DNS route as success", () => {
     expect(isBenignRouteError("Failed to add route: record already exists")).toBe(true);
+  });
+
+  it("forces an existing hostname onto the selected workspace tunnel", async () => {
+    const binary = makeTmpDir("cloudflared-route");
+    stateDirs.push(binary);
+    const log = path.join(binary, "args.txt");
+    const fake = path.join(binary, "cloudflared");
+    fs.writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' "$@" > "${log}"\n`, { mode: 0o755 });
+    const account = new ProcessCloudflaredAccount(fake);
+    await account.routeDns("c2c-workspace", "c2c-demo.example.com");
+    expect(fs.readFileSync(log, "utf8").split("\n")).toEqual([
+      "tunnel",
+      "route",
+      "dns",
+      "--overwrite-dns",
+      "c2c-workspace",
+      "c2c-demo.example.com",
+      "",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- start named tunnels with an explicit empty cloudflared config so unrelated user ingress rules cannot select the wrong tunnel
- pass `--overwrite-dns` when routing the configured hostname so recreated workspace tunnels replace stale Cloudflare records
- cover the exact route command with a regression test

This addresses the Cloudflare 530 failure where a hostname still points at an older tunnel ID.

## Verification

- `pnpm test -- --run tests/tunnel.test.ts` (176 tests passed in the repository suite)
- `pnpm typecheck`
- `git diff --check`

Fixes #417